### PR TITLE
Extract app storage and diffing logic into separate modules

### DIFF
--- a/lib/mix/tasks/phx_diff.gen.diffs.ex
+++ b/lib/mix/tasks/phx_diff.gen.diffs.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.PhxDiff.Gen.Diffs do
 
   def run(_) do
     Mix.shell().info([:yellow, "Generating diffs..."])
-    PhxDiff.Diffs.generate()
+    PhxDiff.Diffs.DiffEngine.generate()
     Mix.shell().info([:green, "Completed generating diffs"])
   end
 end

--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -1,0 +1,43 @@
+defmodule PhxDiff.Diffs.AppRepo do
+  @moduledoc false
+
+  @type version :: Phoenix.Diffs.version()
+
+  @sample_app_path "data/sample-app"
+
+  @spec all_versions() :: [version]
+  def all_versions do
+    @sample_app_path
+    |> File.ls!()
+    |> Enum.sort_by(&Version.parse!/1, &(Version.compare(&1, &2) == :lt))
+  end
+
+  @spec release_versions() :: [version]
+  def release_versions, do: all_versions() |> Enum.reject(&pre_release?/1)
+
+  defp pre_release?(version), do: !Enum.empty?(Version.parse!(version).pre)
+
+  @spec latest_version() :: version
+  def latest_version, do: all_versions() |> List.last()
+
+  @spec previous_release_version() :: version
+  def previous_release_version do
+    releases = release_versions()
+    latest_release = releases |> List.last()
+
+    if latest_version() == latest_release do
+      releases |> Enum.at(-2)
+    else
+      latest_release
+    end
+  end
+
+  @spec fetch_app_path(version) :: {:ok, String.t()} | {:error, :invalid_version}
+  def fetch_app_path(version) do
+    if version in all_versions() do
+      {:ok, "#{@sample_app_path}/#{version}"}
+    else
+      {:error, :invalid_version}
+    end
+  end
+end

--- a/lib/phx_diff/diffs/diff_engine.ex
+++ b/lib/phx_diff/diffs/diff_engine.ex
@@ -1,0 +1,57 @@
+defmodule PhxDiff.Diffs.DiffEngine do
+  @moduledoc false
+
+  alias PhxDiff.Diffs.AppRepo
+
+  @type version :: PhxDiff.Diffs.version()
+  @type diff :: PhxDiff.Diffs.diff()
+
+  @diffs_path "data/diffs"
+
+  @spec get_diff(version, version) :: {:ok, diff} | {:error, :invalid_versions}
+  def get_diff(source_version, target_version) do
+    case File.read(diff_file_path(source_version, target_version)) do
+      {:error, _} -> {:error, :invalid_versions}
+      result -> result
+    end
+  end
+
+  @spec generate :: :ok
+  def generate do
+    versions = AppRepo.all_versions()
+
+    version_tuples =
+      Enum.concat(
+        Enum.map(versions, fn source_version ->
+          Enum.map(versions, fn target_version ->
+            {source_version, target_version}
+          end)
+        end)
+      )
+
+    _ =
+      version_tuples
+      |> Task.async_stream(&generate_diff_content/1)
+      |> Enum.to_list()
+
+    :ok
+  end
+
+  defp generate_diff_content({source_version, target_version}) do
+    {:ok, source_path} = AppRepo.fetch_app_path(source_version)
+    {:ok, target_path} = AppRepo.fetch_app_path(target_version)
+
+    {result, _exit_code} = System.cmd("git", ["diff", "--no-index", source_path, target_path])
+
+    content =
+      result
+      |> String.replace("a/#{source_path}/", "")
+      |> String.replace("b/#{target_path}/", "")
+
+    File.write!(diff_file_path(source_version, target_version), content)
+  end
+
+  defp diff_file_path(source_version, target_version) do
+    "#{@diffs_path}/#{source_version}--#{target_version}.diff"
+  end
+end

--- a/lib/phx_diff/diffs/diffs.ex
+++ b/lib/phx_diff/diffs/diffs.ex
@@ -1,81 +1,26 @@
 defmodule PhxDiff.Diffs do
-  @sample_app_path "data/sample-app"
-  @diffs_path "data/diffs"
+  @moduledoc """
+  Primary API for retrieving diffs
+  """
+
+  alias PhxDiff.Diffs.AppRepo
+  alias PhxDiff.Diffs.DiffEngine
 
   @type diff :: String.t()
   @type version :: String.t()
 
   @spec all_versions() :: [version]
-  def all_versions do
-    @sample_app_path
-    |> File.ls!()
-    |> Enum.sort_by(&Version.parse!/1, &(Version.compare(&1, &2) == :lt))
-  end
+  defdelegate all_versions, to: AppRepo
 
   @spec release_versions() :: [version]
-  def release_versions, do: all_versions() |> Enum.reject(&pre_release?/1)
-
-  defp pre_release?(version), do: !Enum.empty?(Version.parse!(version).pre)
+  defdelegate release_versions, to: AppRepo
 
   @spec latest_version() :: version
-  def latest_version, do: all_versions() |> List.last()
+  defdelegate latest_version, to: AppRepo
 
   @spec previous_release_version() :: version
-  def previous_release_version do
-    releases = release_versions()
-    latest_release = releases |> List.last()
-
-    if latest_version() == latest_release do
-      releases |> Enum.at(-2)
-    else
-      latest_release
-    end
-  end
+  defdelegate previous_release_version, to: AppRepo
 
   @spec get_diff(version, version) :: {:ok, diff} | {:error, :invalid_versions}
-  def get_diff(source_version, target_version) do
-    case File.read(diff_file_path(source_version, target_version)) do
-      {:error, _} -> {:error, :invalid_versions}
-      result -> result
-    end
-  end
-
-  @spec generate :: :ok
-  def generate do
-    versions = all_versions()
-
-    version_tuples =
-      Enum.concat(
-        Enum.map(versions, fn source_version ->
-          Enum.map(versions, fn target_version ->
-            {source_version, target_version}
-          end)
-        end)
-      )
-
-    _ =
-      version_tuples
-      |> Task.async_stream(&generate_diff_content/1)
-      |> Enum.to_list()
-
-    :ok
-  end
-
-  defp generate_diff_content({source_version, target_version}) do
-    source_path = "#{@sample_app_path}/#{source_version}"
-    target_path = "#{@sample_app_path}/#{target_version}"
-
-    {result, _exit_code} = System.cmd("git", ["diff", "--no-index", source_path, target_path])
-
-    content =
-      result
-      |> String.replace("a/#{source_path}/", "")
-      |> String.replace("b/#{target_path}/", "")
-
-    File.write!(diff_file_path(source_version, target_version), content)
-  end
-
-  defp diff_file_path(source_version, target_version) do
-    "#{@diffs_path}/#{source_version}--#{target_version}.diff"
-  end
+  defdelegate get_diff(source_version, target_version), to: DiffEngine
 end

--- a/lib/phx_diff/diffs/diffs.ex
+++ b/lib/phx_diff/diffs/diffs.ex
@@ -2,18 +2,25 @@ defmodule PhxDiff.Diffs do
   @sample_app_path "data/sample-app"
   @diffs_path "data/diffs"
 
+  @type diff :: String.t()
+  @type version :: String.t()
+
+  @spec all_versions() :: [version]
   def all_versions do
     @sample_app_path
     |> File.ls!()
     |> Enum.sort_by(&Version.parse!/1, &(Version.compare(&1, &2) == :lt))
   end
 
+  @spec release_versions() :: [version]
   def release_versions, do: all_versions() |> Enum.reject(&pre_release?/1)
 
   defp pre_release?(version), do: !Enum.empty?(Version.parse!(version).pre)
 
+  @spec latest_version() :: version
   def latest_version, do: all_versions() |> List.last()
 
+  @spec previous_release_version() :: version
   def previous_release_version do
     releases = release_versions()
     latest_release = releases |> List.last()
@@ -25,13 +32,15 @@ defmodule PhxDiff.Diffs do
     end
   end
 
+  @spec get_diff(version, version) :: {:ok, diff} | {:error, :invalid_versions}
   def get_diff(source_version, target_version) do
     case File.read(diff_file_path(source_version, target_version)) do
-      {:error, _} -> {:error, "Invalid versions"}
+      {:error, _} -> {:error, :invalid_versions}
       result -> result
     end
   end
 
+  @spec generate :: :ok
   def generate do
     versions = all_versions()
 

--- a/test/phx_diff/diffs/diffs_test.exs
+++ b/test/phx_diff/diffs/diffs_test.exs
@@ -39,7 +39,7 @@ defmodule PhxDiff.DiffsTest do
     end
 
     test "returns error when a version is invalid" do
-      {:error, "Invalid versions"} = Diffs.get_diff("1.3.1", "invalid")
+      {:error, :invalid_versions} = Diffs.get_diff("1.3.1", "invalid")
     end
   end
 end


### PR DESCRIPTION
In an effort to make it easier to do dynamic diffing between versions (instead of pre-generating them), I'd like to propose that we split the logic from `PhxDiff.Diffs` into two private child modules:

* `PhxDiff.Diffs.AppRepo` - This module provides an interface listing the available phoenix versions, and getting a path for a specific version of the sample app to be used with diffing.
* `PhxDiff.Diffs.DiffEngine` - This module's primary function is `get_diff/2` which returns the diff between a source and a target version of the phoenix app. All of the static diff generation code has been moved in here as well.

All calls from the web app are still routed through the primary `PhxDiff.Diffs` API, but now it delegates to the appropriate underlying module. This will make it easier to rewrite one of the components of the app, without having to touch the other.

Since we are doing some delegation, I also added typespecs as documentation so it's easy to quickly see each function's return values. There's no dialyzer checking of these, but it could definitely be added.