### PR TITLE
Introduce AppSpecification struct for holding phoenix version + opts

### DIFF
--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -1,14 +1,17 @@
 defmodule PhxDiff.Diffs.AppRepo do
   @moduledoc false
 
+  alias PhxDiff.Diffs.AppSpecification
+
   @type version :: Phoenix.Diffs.version()
 
   @sample_app_path "data/sample-app"
 
   @spec all_versions() :: [version]
   def all_versions do
-    @sample_app_path
-    |> File.ls!()
+    app_specifications_for_pre_generated_apps()
+    |> MapSet.new(& &1.phoenix_version)
+    |> MapSet.to_list()
     |> Enum.sort_by(&Version.parse!/1, &(Version.compare(&1, &2) == :lt))
   end
 
@@ -32,12 +35,24 @@ defmodule PhxDiff.Diffs.AppRepo do
     end
   end
 
-  @spec fetch_app_path(version) :: {:ok, String.t()} | {:error, :invalid_version}
-  def fetch_app_path(version) do
-    if version in all_versions() do
-      {:ok, "#{@sample_app_path}/#{version}"}
+  @spec fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, :invalid_version}
+  def fetch_app_path(%AppSpecification{} = app_specification) do
+    if app_generated_for_specification?(app_specification) do
+      {:ok, app_path(app_specification)}
     else
       {:error, :invalid_version}
     end
+  end
+
+  defp app_generated_for_specification?(%AppSpecification{} = app_specification) do
+    app_specification in app_specifications_for_pre_generated_apps()
+  end
+
+  defp app_path(%AppSpecification{phoenix_version: version}), do: "#{@sample_app_path}/#{version}"
+
+  defp app_specifications_for_pre_generated_apps do
+    @sample_app_path
+    |> File.ls!()
+    |> Enum.map(&AppSpecification.new/1)
   end
 end

--- a/lib/phx_diff/diffs/app_specification.ex
+++ b/lib/phx_diff/diffs/app_specification.ex
@@ -1,0 +1,20 @@
+defmodule PhxDiff.Diffs.AppSpecification do
+  @moduledoc """
+  A specification for the application that should be compared
+  """
+
+  defstruct [:phoenix_version]
+
+  @type version :: PhxDiff.Diffs.version()
+  @type t :: %__MODULE__{
+          phoenix_version: version
+        }
+
+  @doc """
+  Builds an new app specification for a basic phoenix app with no options
+  """
+  @spec new(version) :: t
+  def new(phoenix_version) when is_binary(phoenix_version) do
+    %__MODULE__{phoenix_version: phoenix_version}
+  end
+end

--- a/lib/phx_diff/diffs/diff_engine.ex
+++ b/lib/phx_diff/diffs/diff_engine.ex
@@ -2,14 +2,15 @@ defmodule PhxDiff.Diffs.DiffEngine do
   @moduledoc false
 
   alias PhxDiff.Diffs.AppRepo
+  alias PhxDiff.Diffs.AppSpecification
 
-  @type version :: PhxDiff.Diffs.version()
   @type diff :: PhxDiff.Diffs.diff()
 
-  @spec get_diff(version, version) :: {:ok, diff} | {:error, :invalid_versions}
-  def get_diff(source_version, target_version) do
-    with {:ok, source_path} <- AppRepo.fetch_app_path(source_version),
-         {:ok, target_path} <- AppRepo.fetch_app_path(target_version) do
+  @spec get_diff(AppSpecification.t(), AppSpecification.t()) ::
+          {:ok, diff} | {:error, :invalid_versions}
+  def get_diff(%AppSpecification{} = source_spec, %AppSpecification{} = target_spec) do
+    with {:ok, source_path} <- AppRepo.fetch_app_path(source_spec),
+         {:ok, target_path} <- AppRepo.fetch_app_path(target_spec) do
       diff = compute_diff!(source_path, target_path)
       {:ok, diff}
     else

--- a/lib/phx_diff/diffs/diffs.ex
+++ b/lib/phx_diff/diffs/diffs.ex
@@ -4,10 +4,12 @@ defmodule PhxDiff.Diffs do
   """
 
   alias PhxDiff.Diffs.AppRepo
+  alias PhxDiff.Diffs.AppSpecification
   alias PhxDiff.Diffs.DiffEngine
 
   @type diff :: String.t()
   @type version :: String.t()
+  @type option :: String.t()
 
   @spec all_versions() :: [version]
   defdelegate all_versions, to: AppRepo
@@ -21,6 +23,7 @@ defmodule PhxDiff.Diffs do
   @spec previous_release_version() :: version
   defdelegate previous_release_version, to: AppRepo
 
-  @spec get_diff(version, version) :: {:ok, diff} | {:error, :invalid_versions}
-  defdelegate get_diff(source_version, target_version), to: DiffEngine
+  @spec get_diff(AppSpecification.t(), AppSpecification.t()) ::
+          {:ok, diff} | {:error, :invalid_versions}
+  defdelegate get_diff(source_spec, target_spec), to: DiffEngine
 end

--- a/lib/phx_diff_web/controllers/diff_controller.ex
+++ b/lib/phx_diff_web/controllers/diff_controller.ex
@@ -2,9 +2,13 @@ defmodule PhxDiffWeb.DiffController do
   use PhxDiffWeb, :controller
 
   alias PhxDiff.Diffs
+  alias PhxDiff.Diffs.AppSpecification
 
   def index(conn, %{"source" => source, "target" => target}) do
-    case Diffs.get_diff(source, target) do
+    source_spec = AppSpecification.new(source)
+    target_spec = AppSpecification.new(target)
+
+    case Diffs.get_diff(source_spec, target_spec) do
       {:ok, diff} ->
         conn
         |> text(diff)

--- a/test/phx_diff/diffs/diffs_test.exs
+++ b/test/phx_diff/diffs/diffs_test.exs
@@ -2,6 +2,7 @@ defmodule PhxDiff.DiffsTest do
   use ExUnit.Case, async: true
 
   alias PhxDiff.Diffs
+  alias PhxDiff.Diffs.AppSpecification
 
   describe "all_versions/0" do
     test "returns all versions" do
@@ -27,19 +28,28 @@ defmodule PhxDiff.DiffsTest do
 
   describe "get_diff/2" do
     test "returns content when versions are valid" do
-      {:ok, diff} = Diffs.get_diff("1.3.1", "1.3.2")
+      source = AppSpecification.new("1.3.1")
+      target = AppSpecification.new("1.3.2")
+
+      {:ok, diff} = Diffs.get_diff(source, target)
 
       assert diff =~ "config/config.exs config/config.exs"
     end
 
     test "returns empty when versions are the same" do
-      {:ok, diff} = Diffs.get_diff("1.3.1", "1.3.1")
+      source = AppSpecification.new("1.3.1")
+      target = AppSpecification.new("1.3.1")
+
+      {:ok, diff} = Diffs.get_diff(source, target)
 
       assert diff == ""
     end
 
     test "returns error when a version is invalid" do
-      {:error, :invalid_versions} = Diffs.get_diff("1.3.1", "invalid")
+      source = AppSpecification.new("1.3.1")
+      target = AppSpecification.new("invalid")
+
+      {:error, :invalid_versions} = Diffs.get_diff(source, target)
     end
   end
 end


### PR DESCRIPTION
In an effort compare apps generated with different options it would be nice to group the phoenix version + options into a single struct that could be passed throughout the system. This PR introduces that struct (AppSpecification) and threads it through the system. It currently only has the `phoenix_version` field on it, but I plan to add a `phoenix_options` field once I've moved the app generation code into elixir. My thought is this struct will be used anywhere we need to describe how an app was/should be generated.