### PR TITLE
Fix dialyzer error

### DIFF
--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -3,7 +3,7 @@ defmodule PhxDiff.Diffs.AppRepo do
 
   alias PhxDiff.Diffs.AppSpecification
 
-  @type version :: Phoenix.Diffs.version()
+  @type version :: PhxDiff.Diffs.version()
 
   @sample_app_path "data/sample-app"
 


### PR DESCRIPTION
Looks like a typo in one of the typespecs was causing the builds to fail

```
:0:unknown_type
Unknown type: Phoenix.Diffs.version/0.
________________________________________________________________________________
done (warnings were emitted)
```

This gets the builds back to green