### PR TITLE
Add integration test coverage for phx_diff.gen.sample

### DIFF
--- a/test/mix/tasks/phx_diff.gen.sample_test.exs
+++ b/test/mix/tasks/phx_diff.gen.sample_test.exs
@@ -1,0 +1,40 @@
+defmodule Mix.Tasks.PhxDiff.Gen.SampleTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.PhxDiff.Gen
+  alias PhxDiff.Diffs.AppSpecification
+
+  test "the appropriate diff is returned after generating 2 versions of an app" do
+    Gen.Sample.run(["1.5.2"])
+    Gen.Sample.run(["1.5.3"])
+
+    assert {:ok, diff} =
+             PhxDiff.Diffs.get_diff(AppSpecification.new("1.5.2"), AppSpecification.new("1.5.3"))
+
+    assert diff =~
+             """
+             @@ -33,11 +33,11 @@
+                # Type `mix help deps` for examples and options.
+                defp deps do
+                  [
+             -      {:phoenix, "~> 1.5.2"},
+             +      {:phoenix, "~> 1.5.3"},
+                    {:phoenix_ecto, "~> 4.1"},
+                    {:ecto_sql, "~> 3.4"},
+                    {:postgrex, ">= 0.0.0"},
+             -      {:phoenix_live_view, "~> 0.12.0"},
+             +      {:phoenix_live_view, "~> 0.13.0"},
+                    {:floki, ">= 0.0.0", only: :test},
+                    {:phoenix_html, "~> 2.11"},
+                    {:phoenix_live_reload, "~> 1.2", only: :dev},
+             """
+  end
+
+  test "errors when a phoenix version isn't specified" do
+    Gen.Sample.run([])
+
+    assert_receive {:mix_shell, :error, [msg]}
+
+    assert msg == "A phoenix version must be specified"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,7 @@
 ExUnit.configure(formatters: [ExUnit.CLIFormatter, ExUnitNotifier])
 
+# Get Mix output sent to the current
+# process to avoid polluting tests.
+Mix.shell(Mix.Shell.Process)
+
 ExUnit.start()


### PR DESCRIPTION
Since I'm planning on doing some work on how sample apps are generated, I thought it would be a good idea to add some test coverage to ensure the diffs still come back as expected.