### PR TITLE
Add optional config param to allow for testing when AppRepo is empty

### DIFF
--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -1,57 +1,67 @@
 defmodule PhxDiff.Diffs.AppRepo do
   @moduledoc false
 
-  alias PhxDiff.Diffs.AppSpecification
+  alias PhxDiff.Diffs.{
+    AppSpecification,
+    Config
+  }
 
   @type version :: PhxDiff.Diffs.version()
 
-  @sample_app_path "data/sample-app"
-
-  @spec all_versions() :: [version]
-  def all_versions do
-    app_specifications_for_pre_generated_apps()
+  @spec all_versions(Config.t()) :: [version]
+  def all_versions(%Config{} = config) do
+    config
+    |> app_specifications_for_pre_generated_apps()
     |> MapSet.new(& &1.phoenix_version)
     |> MapSet.to_list()
     |> Enum.sort_by(&Version.parse!/1, &(Version.compare(&1, &2) == :lt))
   end
 
-  @spec release_versions() :: [version]
-  def release_versions, do: all_versions() |> Enum.reject(&pre_release?/1)
+  @spec release_versions(Config.t()) :: [version]
+  def release_versions(%Config{} = config),
+    do: config |> all_versions() |> Enum.reject(&pre_release?/1)
 
   defp pre_release?(version), do: !Enum.empty?(Version.parse!(version).pre)
 
-  @spec latest_version() :: version
-  def latest_version, do: all_versions() |> List.last()
+  @spec latest_version(Config.t()) :: version
+  def latest_version(%Config{} = config),
+    do: config |> all_versions() |> List.last()
 
-  @spec previous_release_version() :: version
-  def previous_release_version do
-    releases = release_versions()
+  @spec previous_release_version(Config.t()) :: version
+  def previous_release_version(%Config{} = config) do
+    releases = release_versions(config)
     latest_release = releases |> List.last()
 
-    if latest_version() == latest_release do
+    if latest_version(config) == latest_release do
       releases |> Enum.at(-2)
     else
       latest_release
     end
   end
 
-  @spec fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, :invalid_version}
-  def fetch_app_path(%AppSpecification{} = app_specification) do
-    if app_generated_for_specification?(app_specification) do
-      {:ok, app_path(app_specification)}
+  @spec fetch_app_path(Config.t(), AppSpecification.t()) ::
+          {:ok, String.t()} | {:error, :invalid_version}
+  def fetch_app_path(%Config{} = config, %AppSpecification{} = app_specification) do
+    if app_generated_for_specification?(config, app_specification) do
+      {:ok, app_path(config, app_specification)}
     else
       {:error, :invalid_version}
     end
   end
 
-  defp app_generated_for_specification?(%AppSpecification{} = app_specification) do
-    app_specification in app_specifications_for_pre_generated_apps()
+  defp app_generated_for_specification?(config, app_spec) do
+    app_spec in app_specifications_for_pre_generated_apps(config)
   end
 
-  defp app_path(%AppSpecification{phoenix_version: version}), do: "#{@sample_app_path}/#{version}"
+  defp app_path(config, app_spec) do
+    %Config{app_repo_path: app_repo_path} = config
+    %AppSpecification{phoenix_version: version} = app_spec
 
-  defp app_specifications_for_pre_generated_apps do
-    @sample_app_path
+    Path.join(app_repo_path, version)
+  end
+
+  defp app_specifications_for_pre_generated_apps(%Config{app_repo_path: app_repo_path}) do
+    app_repo_path
     |> File.ls!()
     |> Enum.map(&AppSpecification.new/1)
   end

--- a/lib/phx_diff/diffs/config.ex
+++ b/lib/phx_diff/diffs/config.ex
@@ -1,0 +1,11 @@
+defmodule PhxDiff.Diffs.Config do
+  @moduledoc """
+  Configuration for PhxDiff
+  """
+
+  defstruct [:app_repo_path]
+
+  @type t :: %__MODULE__{
+          app_repo_path: String.t()
+        }
+end

--- a/lib/phx_diff/diffs/diff_engine.ex
+++ b/lib/phx_diff/diffs/diff_engine.ex
@@ -1,32 +1,10 @@
 defmodule PhxDiff.Diffs.DiffEngine do
   @moduledoc false
 
-  alias PhxDiff.Diffs.{
-    AppRepo,
-    AppSpecification,
-    Config
-  }
-
   @type diff :: PhxDiff.Diffs.diff()
 
-  @spec get_diff(Config.t(), AppSpecification.t(), AppSpecification.t()) ::
-          {:ok, diff} | {:error, :invalid_versions}
-  def get_diff(
-        %Config{} = config,
-        %AppSpecification{} = source_spec,
-        %AppSpecification{} = target_spec
-      ) do
-    with {:ok, source_path} <- AppRepo.fetch_app_path(config, source_spec),
-         {:ok, target_path} <- AppRepo.fetch_app_path(config, target_spec) do
-      diff = compute_diff!(source_path, target_path)
-      {:ok, diff}
-    else
-      {:error, :invalid_version} -> {:error, :invalid_versions}
-    end
-  end
-
-  @spec compute_diff!(String.t(), String.t()) :: diff
-  defp compute_diff!(source_path, target_path) do
+  @spec compute_diff(String.t(), String.t()) :: diff
+  def compute_diff(source_path, target_path) do
     {result, _exit_code} = System.cmd("diff", ["-ruN", source_path, target_path])
 
     result

--- a/lib/phx_diff/diffs/diff_engine.ex
+++ b/lib/phx_diff/diffs/diff_engine.ex
@@ -1,16 +1,23 @@
 defmodule PhxDiff.Diffs.DiffEngine do
   @moduledoc false
 
-  alias PhxDiff.Diffs.AppRepo
-  alias PhxDiff.Diffs.AppSpecification
+  alias PhxDiff.Diffs.{
+    AppRepo,
+    AppSpecification,
+    Config
+  }
 
   @type diff :: PhxDiff.Diffs.diff()
 
-  @spec get_diff(AppSpecification.t(), AppSpecification.t()) ::
+  @spec get_diff(Config.t(), AppSpecification.t(), AppSpecification.t()) ::
           {:ok, diff} | {:error, :invalid_versions}
-  def get_diff(%AppSpecification{} = source_spec, %AppSpecification{} = target_spec) do
-    with {:ok, source_path} <- AppRepo.fetch_app_path(source_spec),
-         {:ok, target_path} <- AppRepo.fetch_app_path(target_spec) do
+  def get_diff(
+        %Config{} = config,
+        %AppSpecification{} = source_spec,
+        %AppSpecification{} = target_spec
+      ) do
+    with {:ok, source_path} <- AppRepo.fetch_app_path(config, source_spec),
+         {:ok, target_path} <- AppRepo.fetch_app_path(config, target_spec) do
       diff = compute_diff!(source_path, target_path)
       {:ok, diff}
     else

--- a/lib/phx_diff/diffs/diffs.ex
+++ b/lib/phx_diff/diffs/diffs.ex
@@ -46,9 +46,15 @@ defmodule PhxDiff.Diffs do
           {:ok, diff} | {:error, :invalid_versions}
   def get_diff(%AppSpecification{} = source_spec, %AppSpecification{} = target_spec, opts \\ [])
       when is_list(opts) do
-    opts
-    |> get_config()
-    |> DiffEngine.get_diff(source_spec, target_spec)
+    config = get_config(opts)
+
+    with {:ok, source_path} <- AppRepo.fetch_app_path(config, source_spec),
+         {:ok, target_path} <- AppRepo.fetch_app_path(config, target_spec) do
+      diff = DiffEngine.compute_diff(source_path, target_path)
+      {:ok, diff}
+    else
+      {:error, :invalid_version} -> {:error, :invalid_versions}
+    end
   end
 
   defp get_config(opts) when is_list(opts) do

--- a/lib/phx_diff/diffs/diffs.ex
+++ b/lib/phx_diff/diffs/diffs.ex
@@ -5,25 +5,57 @@ defmodule PhxDiff.Diffs do
 
   alias PhxDiff.Diffs.AppRepo
   alias PhxDiff.Diffs.AppSpecification
+  alias PhxDiff.Diffs.Config
   alias PhxDiff.Diffs.DiffEngine
 
   @type diff :: String.t()
   @type version :: String.t()
   @type option :: String.t()
 
-  @spec all_versions() :: [version]
-  defdelegate all_versions, to: AppRepo
+  @type config_opt :: {:config, Config.t()}
 
-  @spec release_versions() :: [version]
-  defdelegate release_versions, to: AppRepo
+  @spec all_versions([config_opt]) :: [version]
+  def all_versions(opts \\ []) when is_list(opts) do
+    opts
+    |> get_config()
+    |> AppRepo.all_versions()
+  end
 
-  @spec latest_version() :: version
-  defdelegate latest_version, to: AppRepo
+  @spec release_versions([config_opt]) :: [version]
+  def release_versions(opts \\ []) when is_list(opts) do
+    opts
+    |> get_config()
+    |> AppRepo.release_versions()
+  end
 
-  @spec previous_release_version() :: version
-  defdelegate previous_release_version, to: AppRepo
+  @spec latest_version([config_opt]) :: version
+  def latest_version(opts \\ []) when is_list(opts) do
+    opts
+    |> get_config()
+    |> AppRepo.latest_version()
+  end
 
-  @spec get_diff(AppSpecification.t(), AppSpecification.t()) ::
+  @spec previous_release_version([config_opt]) :: version
+  def previous_release_version(opts \\ []) when is_list(opts) do
+    opts
+    |> get_config()
+    |> AppRepo.previous_release_version()
+  end
+
+  @spec get_diff(AppSpecification.t(), AppSpecification.t(), [config_opt]) ::
           {:ok, diff} | {:error, :invalid_versions}
-  defdelegate get_diff(source_spec, target_spec), to: DiffEngine
+  def get_diff(%AppSpecification{} = source_spec, %AppSpecification{} = target_spec, opts \\ [])
+      when is_list(opts) do
+    opts
+    |> get_config()
+    |> DiffEngine.get_diff(source_spec, target_spec)
+  end
+
+  defp get_config(opts) when is_list(opts) do
+    Keyword.get_lazy(opts, :config, &default_config/0)
+  end
+
+  defp default_config do
+    %Config{app_repo_path: "data/sample-app"}
+  end
 end

--- a/test/phx_diff/diffs/diffs_test.exs
+++ b/test/phx_diff/diffs/diffs_test.exs
@@ -1,10 +1,16 @@
 defmodule PhxDiff.DiffsTest do
   use ExUnit.Case, async: true
 
-  alias PhxDiff.Diffs
-  alias PhxDiff.Diffs.AppSpecification
+  import PhxDiff.TestSupport.FileHelpers
 
-  describe "all_versions/0" do
+  alias PhxDiff.Diffs
+
+  alias PhxDiff.Diffs.{
+    AppSpecification,
+    Config
+  }
+
+  describe "all_versions/1" do
     test "returns all versions" do
       versions = Diffs.all_versions()
 
@@ -13,9 +19,17 @@ defmodule PhxDiff.DiffsTest do
       assert versions |> Enum.member?("1.3.0")
       assert versions |> Enum.member?("1.4.0-rc.2")
     end
+
+    test "returns an empty list when no apps have been generated" do
+      with_tmp(fn path ->
+        config = build_config(path)
+
+        assert [] = Diffs.all_versions(config: config)
+      end)
+    end
   end
 
-  describe "release_versions/0" do
+  describe "release_versions/1" do
     test "returns all versions" do
       versions = Diffs.release_versions()
 
@@ -24,9 +38,17 @@ defmodule PhxDiff.DiffsTest do
       assert versions |> Enum.member?("1.3.0")
       refute versions |> Enum.member?("1.4.0-rc.2")
     end
+
+    test "returns an empty list when no apps have been generated" do
+      with_tmp(fn path ->
+        config = build_config(path)
+
+        assert [] = Diffs.release_versions(config: config)
+      end)
+    end
   end
 
-  describe "get_diff/2" do
+  describe "get_diff/3" do
     test "returns content when versions are valid" do
       source = AppSpecification.new("1.3.1")
       target = AppSpecification.new("1.3.2")
@@ -51,5 +73,20 @@ defmodule PhxDiff.DiffsTest do
 
       {:error, :invalid_versions} = Diffs.get_diff(source, target)
     end
+
+    test "returns an error when an app hasn't been generated for the given version" do
+      with_tmp(fn path ->
+        config = build_config(path)
+
+        source = AppSpecification.new("1.3.1")
+        target = AppSpecification.new("1.4.2")
+
+        assert {:error, :invalid_versions} = Diffs.get_diff(source, target, config: config)
+      end)
+    end
+  end
+
+  defp build_config(tmp_path) do
+    %Config{app_repo_path: tmp_path}
   end
 end

--- a/test/support/file_helpers.ex
+++ b/test/support/file_helpers.ex
@@ -1,0 +1,50 @@
+defmodule PhxDiff.TestSupport.FileHelpers do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but does not"
+  end
+
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} to not exist, but it does"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      is_list(match) ->
+        assert_file(file, &Enum.each(match, fn m -> assert &1 =~ m end))
+
+      is_binary(match) or Regex.regex?(match) ->
+        assert_file(file, &assert(&1 =~ match))
+
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+
+      true ->
+        raise inspect({file, match})
+    end
+  end
+
+  def tmp_path do
+    Path.expand("../../tmp/test/", __DIR__)
+  end
+
+  defp random_string(len) do
+    len |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, len)
+  end
+
+  def with_tmp(function) do
+    path = Path.join([tmp_path(), random_string(10)])
+
+    try do
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      function.(path)
+    after
+      File.rm_rf!(path)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an optional config param to the functions on `PhxDiff.Diff` and allows changing the app repo path to an empty directory. This becomes very useful when testing app generation in the next PR so the test doesn't have to delete files in `data/sample-app/<version>`. I chose the config param approach over changing the application environment so tests can run in parallel and so I don't have to adjust the application environment on every test.

The other change in this PR was to simplify `DiffEngine` and just pass in the paths to compute_diff and let the app lookup occur in `PhxDiff.Diffs`. It didn't seem like there was a reason that `DiffEngine` needed to depend on `AppRepo`.