### PR TITLE
Upgrade to latest .credo.exs

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -10,7 +10,7 @@
   configs: [
     %{
       #
-      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # Run any config using `mix credo -C <name>`. If no config name is given
       # "default" is used.
       #
       name: "default",
@@ -21,9 +21,22 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
       #
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
@@ -33,7 +46,11 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: true,
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
       #
       # If you want to use uncolored output by default, you can change `color`
       # to `false` below:
@@ -64,14 +81,8 @@
         # You can customize the priority of any check
         # Priority values are: `low, normal, high, higher`
         #
-        {Credo.Check.Design.AliasUsage, false},
-        # For some checks, you can also set other parameters
-        #
-        # If you don't want the `setup` and `test` macro calls in ExUnit tests
-        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
-        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
-        #
-        {Credo.Check.Design.DuplicatedCode, [excluded_macros: []]},
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
         # set this value to 0 (zero).
@@ -87,36 +98,35 @@
         {Credo.Check.Readability.LargeNumbers, []},
         {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
         {Credo.Check.Readability.ModuleAttributeNames, []},
-        {Credo.Check.Readability.ModuleDoc, false},
+        {Credo.Check.Readability.ModuleDoc, []},
         {Credo.Check.Readability.ModuleNames, []},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
         {Credo.Check.Readability.ParenthesesInCondition, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
         {Credo.Check.Readability.PredicateFunctionNames, []},
         {Credo.Check.Readability.PreferImplicitTry, []},
         {Credo.Check.Readability.RedundantBlankLines, []},
+        {Credo.Check.Readability.Semicolons, []},
+        {Credo.Check.Readability.SpaceAfterCommas, []},
         {Credo.Check.Readability.StringSigils, []},
         {Credo.Check.Readability.TrailingBlankLine, []},
         {Credo.Check.Readability.TrailingWhiteSpace, []},
+        {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
         {Credo.Check.Readability.VariableNames, []},
-        {Credo.Check.Readability.Semicolons, []},
-        {Credo.Check.Readability.SpaceAfterCommas, []},
 
         #
         ## Refactoring Opportunities
         #
-        {Credo.Check.Refactor.DoubleBooleanNegation, []},
         {Credo.Check.Refactor.CondStatements, []},
         {Credo.Check.Refactor.CyclomaticComplexity, []},
         {Credo.Check.Refactor.FunctionArity, []},
         {Credo.Check.Refactor.LongQuoteBlocks, []},
-        {Credo.Check.Refactor.MapInto, false},
+        {Credo.Check.Refactor.MapInto, []},
         {Credo.Check.Refactor.MatchInCondition, []},
         {Credo.Check.Refactor.NegatedConditionsInUnless, []},
         {Credo.Check.Refactor.NegatedConditionsWithElse, []},
         {Credo.Check.Refactor.Nesting, []},
-        {Credo.Check.Refactor.PipeChainStart,
-         [excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []]},
         {Credo.Check.Refactor.UnlessWithElse, []},
+        {Credo.Check.Refactor.WithClauses, []},
 
         #
         ## Warnings
@@ -125,9 +135,11 @@
         {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
         {Credo.Check.Warning.IExPry, []},
         {Credo.Check.Warning.IoInspect, []},
-        {Credo.Check.Warning.LazyLogging, false},
+        {Credo.Check.Warning.LazyLogging, []},
+        {Credo.Check.Warning.MixEnv, false},
         {Credo.Check.Warning.OperationOnSameValues, []},
         {Credo.Check.Warning.OperationWithConstantResult, []},
+        {Credo.Check.Warning.RaiseInsideRescue, []},
         {Credo.Check.Warning.UnusedEnumOperation, []},
         {Credo.Check.Warning.UnusedFileOperation, []},
         {Credo.Check.Warning.UnusedKeywordOperation, []},
@@ -136,21 +148,33 @@
         {Credo.Check.Warning.UnusedRegexOperation, []},
         {Credo.Check.Warning.UnusedStringOperation, []},
         {Credo.Check.Warning.UnusedTupleOperation, []},
-        {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.UnsafeExec, []},
 
         #
-        # Controversial and experimental checks (opt-in, just remove `, false`)
+        # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
         #
+        # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
+        #
+        {Credo.Check.Readability.StrictModuleLayout, false},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Consistency.UnusedVariableNames, false},
+        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Readability.AliasAs, false},
+        {Credo.Check.Readability.MultiAlias, false},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Readability.SinglePipe, false},
+        {Credo.Check.Readability.WithCustomTaggedTuple, false},
         {Credo.Check.Refactor.ABCSize, false},
         {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.DoubleBooleanNegation, false},
+        {Credo.Check.Refactor.ModuleDependencies, false},
+        {Credo.Check.Refactor.NegatedIsNil, false},
+        {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.LeakyEnvironment, false},
         {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-
-        #
-        # Deprecated checks (these will be deleted after a grace period)
-        #
-        {Credo.Check.Readability.Specs, false}
+        {Credo.Check.Warning.UnsafeToAtom, false}
 
         #
         # Custom checks can be created using `mix credo.gen.check`.

--- a/lib/mix/tasks/phx_diff.add.ex
+++ b/lib/mix/tasks/phx_diff.add.ex
@@ -1,9 +1,12 @@
 defmodule Mix.Tasks.PhxDiff.Add do
+  @moduledoc false
   use Mix.Task
+
+  alias Mix.Tasks.PhxDiff.Gen
 
   @shortdoc "Add a version of phoenix to phoenix diff"
 
   def run(args) do
-    Mix.Tasks.PhxDiff.Gen.Sample.run(args)
+    Gen.Sample.run(args)
   end
 end

--- a/lib/mix/tasks/phx_diff.gen.sample.ex
+++ b/lib/mix/tasks/phx_diff.gen.sample.ex
@@ -1,11 +1,14 @@
 defmodule Mix.Tasks.PhxDiff.Gen.Sample do
+  @moduledoc false
   use Mix.Task
+
+  alias Mix.Tasks.Cmd
 
   @shortdoc "Generate a sample app for a phoenix version"
 
   def run(args) do
     if length(args) == 1 do
-      Mix.Tasks.Cmd.run(["./bin/generate-sample-app"] ++ args)
+      Cmd.run(["./bin/generate-sample-app"] ++ args)
     else
       Mix.shell().error([:red, "A phoenix version must be specified"])
     end

--- a/lib/mix/tasks/yarn.ex
+++ b/lib/mix/tasks/yarn.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Yarn do
+  @moduledoc false
   use Mix.Task
 
   @shortdoc "Run yarn within assets directory"

--- a/lib/mix/tasks/yarn/build.ex
+++ b/lib/mix/tasks/yarn/build.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Yarn.Build do
+  @moduledoc false
   use Mix.Task
 
   @shortdoc "Run yarn build within assets directory"

--- a/lib/mix/tasks/yarn/deploy.ex
+++ b/lib/mix/tasks/yarn/deploy.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Yarn.Deploy do
+  @moduledoc false
   use Mix.Task
 
   @shortdoc "Run yarn deploy within assets directory"

--- a/lib/mix/tasks/yarn/lint.ex
+++ b/lib/mix/tasks/yarn/lint.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Yarn.Lint do
+  @moduledoc false
   use Mix.Task
 
   @shortdoc "Run yarn lint within assets directory"

--- a/lib/mix/tasks/yarn/test.ex
+++ b/lib/mix/tasks/yarn/test.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Yarn.Test do
+  @moduledoc false
   use Mix.Task
 
   @shortdoc "Run yarn test within assets directory"


### PR DESCRIPTION
This upgrades .credo.exs to the latest version generated by credo 1.4.0. This was originally facing a CI failure for a pipeline not starting with a raw value, a check I knew had been disabled later versions of credo. These are now all of credo's default settings and I added a couple `alias`es and `moduledoc false` statements to get everything passing.