### PR TITLE
Add arguments to app specifications

### DIFF
--- a/lib/mix/tasks/phx_diff.gen.sample.ex
+++ b/lib/mix/tasks/phx_diff.gen.sample.ex
@@ -3,28 +3,22 @@ defmodule Mix.Tasks.PhxDiff.Gen.Sample do
   use Mix.Task
 
   alias PhxDiff.Diffs
-  alias PhxDiff.Diffs.AppSpecification
 
   @shortdoc "Generate a sample app for a phoenix version"
 
   def run([arg]) do
-    arg
-    |> AppSpecification.new()
-    |> Diffs.generate_sample_app()
-    |> case do
-      {:ok, app_path} ->
-        Mix.shell().info("""
+    with {:ok, app_spec} <- Diffs.fetch_default_app_specification(arg),
+         {:ok, app_path} <- Diffs.generate_sample_app(app_spec) do
+      Mix.shell().info("""
 
-        Successfully generated sample app.
+      Successfully generated sample app.
 
-        To add this to version control, run:
+      To add this to version control, run:
 
-            git add #{app_path}
-            git add -f #{app_path}/config/prod.secret.exs
-        """)
-
-        :ok
-
+          git add #{app_path}
+          git add -f #{app_path}/config/prod.secret.exs
+      """)
+    else
       {:error, :invalid_version} ->
         Mix.shell().error([:red, "Invalid version: ", inspect(arg)])
 

--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -1,6 +1,8 @@
 defmodule PhxDiff.Diffs.AppRepo do
   @moduledoc false
 
+  alias PhxDiff.Diffs
+
   alias PhxDiff.Diffs.{
     AppRepo.AppGenerator,
     AppSpecification,
@@ -51,7 +53,7 @@ defmodule PhxDiff.Diffs.AppRepo do
   end
 
   @spec generate_sample_app(Config.t(), AppSpecification.t()) ::
-          {:ok, String.t()} | {:error, :invalid_version | :unknown_version}
+          {:ok, String.t()} | {:error, :unknown_version}
   def generate_sample_app(%Config{} = config, %AppSpecification{} = app_spec) do
     with {:ok, app_dir} <- AppGenerator.generate(config, app_spec),
          {:ok, path_in_storage} <- store_generated_app(config, app_spec, app_dir) do
@@ -84,7 +86,7 @@ defmodule PhxDiff.Diffs.AppRepo do
   defp app_specifications_for_pre_generated_apps(%Config{app_repo_path: app_repo_path}) do
     case File.ls(app_repo_path) do
       {:ok, files} ->
-        Enum.map(files, &AppSpecification.new/1)
+        Enum.map(files, &Diffs.fetch_default_app_specification!/1)
 
       {:error, _reason} ->
         []

--- a/lib/phx_diff/diffs/app_repo/app_generator.ex
+++ b/lib/phx_diff/diffs/app_repo/app_generator.ex
@@ -18,20 +18,22 @@ defmodule PhxDiff.Diffs.AppRepo.AppGenerator do
 
     with {:ok, mix_archives_path} <-
            MixArchivesDirectories.fetch_path_for_phoenix_version(workspace_path, version) do
-      generate_sample_app(workspace_path, mix_archives_path)
+      generate_sample_app(workspace_path, mix_archives_path, app_specification)
     end
   end
 
-  defp generate_sample_app(workspace_path, mix_archives_path) do
+  defp generate_sample_app(workspace_path, mix_archives_path, app_specification) do
     sample_app_path = generate_sample_app_path(workspace_path)
 
-    with :ok <- run_phoenix_generator(sample_app_path, mix_archives_path),
+    with :ok <- run_phoenix_generator(sample_app_path, mix_archives_path, app_specification),
          :ok <- clean_up_generated_app!(sample_app_path) do
       {:ok, sample_app_path}
     end
   end
 
-  defp run_phoenix_generator(sample_app_path, mix_archives_path) do
+  defp run_phoenix_generator(sample_app_path, mix_archives_path, app_specification) do
+    %AppSpecification{phx_new_arguments: arguments} = app_specification
+
     {_output, 0} =
       MixTaskRunner.run(
         [
@@ -40,9 +42,8 @@ defmodule PhxDiff.Diffs.AppRepo.AppGenerator do
           "--module",
           "SampleApp",
           "--app",
-          "sample_app",
-          "--live"
-        ],
+          "sample_app"
+        ] ++ arguments,
         env: [{"MIX_ARCHIVES", mix_archives_path}],
         prompt_responses: [:no_to_all]
       )

--- a/lib/phx_diff/diffs/app_repo/app_generator.ex
+++ b/lib/phx_diff/diffs/app_repo/app_generator.ex
@@ -11,7 +11,7 @@ defmodule PhxDiff.Diffs.AppRepo.AppGenerator do
   @type generate_opt :: {:workspace_path, String.t()}
 
   @spec generate(Config.t(), AppSpecification.t()) ::
-          {:ok, dir} | {:error, :invalid_version | :unknown_version}
+          {:ok, dir} | {:error, :unknown_version}
   def generate(%Config{} = config, %AppSpecification{} = app_specification) do
     %Config{app_generator_workspace_path: workspace_path} = config
     %AppSpecification{phoenix_version: version} = app_specification

--- a/lib/phx_diff/diffs/app_repo/app_generator/mix_archives_directories.ex
+++ b/lib/phx_diff/diffs/app_repo/app_generator/mix_archives_directories.ex
@@ -5,18 +5,14 @@ defmodule PhxDiff.Diffs.AppRepo.AppGenerator.MixArchivesDirectories do
   @type path :: String.t()
 
   @spec fetch_path_for_phoenix_version(path, version) ::
-          {:ok, path} | {:error, :invalid_version | :unknown_version}
+          {:ok, path} | {:error, :unknown_version}
   def fetch_path_for_phoenix_version(workspace_path, version) do
-    with :ok <- validate_version(version) do
-      find_or_create_mix_archives_path_for_phoenix_version(workspace_path, version)
-    end
+    validate_version!(version)
+    find_or_create_mix_archives_path_for_phoenix_version(workspace_path, version)
   end
 
-  defp validate_version(version) do
-    case Version.parse(version) do
-      {:ok, _} -> :ok
-      :error -> {:error, :invalid_version}
-    end
+  defp validate_version!(version) do
+    Version.parse!(version)
   end
 
   defp find_or_create_mix_archives_path_for_phoenix_version(workspace_path, version) do

--- a/lib/phx_diff/diffs/app_specification.ex
+++ b/lib/phx_diff/diffs/app_specification.ex
@@ -3,18 +3,17 @@ defmodule PhxDiff.Diffs.AppSpecification do
   A specification for the application that should be compared
   """
 
-  defstruct [:phoenix_version]
+  defstruct [:phoenix_version, :phx_new_arguments]
 
   @type version :: PhxDiff.Diffs.version()
   @type t :: %__MODULE__{
-          phoenix_version: version
+          phoenix_version: version,
+          phx_new_arguments: [String.t()]
         }
 
-  @doc """
-  Builds an new app specification for a basic phoenix app with no options
-  """
-  @spec new(version) :: t
-  def new(phoenix_version) when is_binary(phoenix_version) do
-    %__MODULE__{phoenix_version: phoenix_version}
+  @doc false
+  @spec new(Version.t(), [String.t()]) :: t
+  def new(%Version{} = phoenix_version, phx_new_arguments) when is_list(phx_new_arguments) do
+    %__MODULE__{phoenix_version: to_string(phoenix_version), phx_new_arguments: phx_new_arguments}
   end
 end

--- a/lib/phx_diff_web/live/page_live.ex
+++ b/lib/phx_diff_web/live/page_live.ex
@@ -4,7 +4,6 @@ defmodule PhxDiffWeb.PageLive do
 
   alias Ecto.Changeset
   alias PhxDiff.Diffs
-  alias PhxDiff.Diffs.AppSpecification
   alias PhxDiffWeb.PageLive.DiffSelection
 
   @impl true
@@ -22,7 +21,11 @@ defmodule PhxDiffWeb.PageLive do
       {:ok, diff_selection} ->
         %DiffSelection{source: source, target: target} = diff_selection
 
-        {:ok, diff} = Diffs.get_diff(AppSpecification.new(source), AppSpecification.new(target))
+        {:ok, diff} =
+          Diffs.get_diff(
+            Diffs.fetch_default_app_specification!(source),
+            Diffs.fetch_default_app_specification!(target)
+          )
 
         {:noreply,
          socket

--- a/test/mix/tasks/phx_diff.gen.sample_test.exs
+++ b/test/mix/tasks/phx_diff.gen.sample_test.exs
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.PhxDiff.Gen.SampleTest do
   use ExUnit.Case, async: true
 
   alias Mix.Tasks.PhxDiff.Gen
-  alias PhxDiff.Diffs.AppSpecification
+  alias PhxDiff.Diffs
 
   test "the appropriate diff is returned after generating 2 versions of an app" do
     Gen.Sample.run(["1.5.2"])
@@ -22,7 +22,10 @@ defmodule Mix.Tasks.PhxDiff.Gen.SampleTest do
     Gen.Sample.run(["1.5.3"])
 
     assert {:ok, diff} =
-             PhxDiff.Diffs.get_diff(AppSpecification.new("1.5.2"), AppSpecification.new("1.5.3"))
+             Diffs.get_diff(
+               Diffs.fetch_default_app_specification!("1.5.2"),
+               Diffs.fetch_default_app_specification!("1.5.3")
+             )
 
     assert diff =~
              """

--- a/test/mix/tasks/phx_diff.gen.sample_test.exs
+++ b/test/mix/tasks/phx_diff.gen.sample_test.exs
@@ -46,6 +46,43 @@ defmodule Mix.Tasks.PhxDiff.Gen.SampleTest do
              """
   end
 
+  test "the appropriate diff is returned when generating phoenix 1.4 apps" do
+    Gen.Sample.run(["1.4.16"])
+
+    assert_receive {:mix_shell, :info, [msg]}
+
+    assert msg == """
+
+           Successfully generated sample app.
+
+           To add this to version control, run:
+
+               git add data/sample-app/1.4.16
+               git add -f data/sample-app/1.4.16/config/prod.secret.exs
+           """
+
+    Gen.Sample.run(["1.4.17"])
+
+    assert {:ok, diff} =
+             Diffs.get_diff(
+               Diffs.fetch_default_app_specification!("1.4.16"),
+               Diffs.fetch_default_app_specification!("1.4.17")
+             )
+
+    assert diff =~
+             """
+             @@ -33,7 +33,7 @@
+                # Type `mix help deps` for examples and options.
+                defp deps do
+                  [
+             -      {:phoenix, "~> 1.4.16"},
+             +      {:phoenix, "~> 1.4.17"},
+                    {:phoenix_pubsub, "~> 1.1"},
+                    {:phoenix_ecto, "~> 4.0"},
+                    {:ecto_sql, "~> 3.1"},
+             """
+  end
+
   test "errors with an invalid version id" do
     Gen.Sample.run(["not_a_version"])
 


### PR DESCRIPTION
This adds the `phx_new_arguments` field to the AppSpecification, so we can have multiple app specifications for the same version with different arguments. This also takes care of the issue where phoenix 1.4 apps could no longer be generated because they didn't use the same --live flag that 1.5 apps take by default. This will also allow us to compare a default 1.5 app with a 1.5 app generated with --live.