### PR TITLE
Display options used to generate apps

### DIFF
--- a/assets/css/pages/_landing-page.scss
+++ b/assets/css/pages/_landing-page.scss
@@ -17,9 +17,18 @@
 
     .version-selectors {
       justify-content: center;
+      display: flex;
+      flex-wrap: wrap;
+    }
+
+    .version-selector{
+      flex: 0 0 150px;
+
+      margin: 10px 6px;
+      text-align: center;
 
       label {
-        margin: 0 6px;
+        margin: 0 6px 2px;
 
         text-transform: uppercase;
         text-decoration: underline;
@@ -30,10 +39,18 @@
       select {
         font-size: 14px;
         width: 100px;
+        margin: 0 auto 2px;
       }
 
-      .form-group {
-        margin: 10px 6px;
+      .generator-options {
+        font-size: 12px;
+      }
+    }
+
+    @include media-breakpoint-up(sm) {
+      .version-selector .field-group{
+        display: flex;
+        align-items: center;
       }
     }
 

--- a/lib/phx_diff_web/live/page_live.html.leex
+++ b/lib/phx_diff_web/live/page_live.html.leex
@@ -8,16 +8,29 @@
           as: :diff_selection,
           phx_change: "diff-changed",
           phx_hook: "DiffSelectorComponent" %>
-        <div class="version-selectors form-inline">
-          <div class="form-group">
-            <%= label f, :source %>
-            <%= select f, :source, @all_versions, class: "form-control" %>
+        <div class="version-selectors">
+          <div class="version-selector version-selector-source">
+            <div class="field-group">
+              <%= label f, :source %>
+              <%= select f, :source, @all_versions, class: "form-control" %>
+            </div>
+            <%= if @source_arguments do %>
+              <div class="generator-options">
+                Generated with <%= @source_arguments %>
+              </div>
+            <% end %>
           </div>
 
-
-          <div class="form-group">
-            <%= label f, :target %>
-            <%= select f, :target, @all_versions, class: "form-control" %>
+          <div class="version-selector version-selector-target">
+            <div class="field-group">
+              <%= label f, :target %>
+              <%= select f, :target, @all_versions, class: "form-control" %>
+            </div>
+            <%= if @target_arguments do %>
+              <div class="generator-options">
+                Generated with <%= @target_arguments %>
+              </div>
+            <% end %>
           </div>
         </div>
       </form>

--- a/test/phx_diff_web/live/page_live_test.exs
+++ b/test/phx_diff_web/live/page_live_test.exs
@@ -102,6 +102,50 @@ defmodule PhxDiffWeb.PageLiveTest do
       )
   end
 
+  @version_with_live_default_option "1.5.0"
+  @version_without_live_default_option "1.4.0"
+
+  test "indicates the options used to generate the source and target apps", %{conn: conn} do
+    {:ok, view, _html} =
+      conn
+      |> live(Routes.page_path(conn, :index))
+      |> follow_redirect(conn)
+
+    view
+    |> element("#diff-selector-form")
+    |> render_change(%{
+      "diff_selection" => %{
+        "source" => @version_with_live_default_option,
+        "target" => @version_without_live_default_option
+      }
+    })
+
+    assert view
+           |> element(".version-selector-source")
+           |> render() =~ "Generated with --live"
+
+    refute view
+           |> element(".version-selector-target")
+           |> render() =~ "Generated with --live"
+
+    view
+    |> element("#diff-selector-form")
+    |> render_change(%{
+      "diff_selection" => %{
+        "source" => @version_without_live_default_option,
+        "target" => @version_with_live_default_option
+      }
+    })
+
+    refute view
+           |> element(".version-selector-source")
+           |> render() =~ "Generated with --live"
+
+    assert view
+           |> element(".version-selector-target")
+           |> render() =~ "Generated with --live"
+  end
+
   defp assert_diff_rendered(view, expected_diff) do
     diff_from_view =
       element(view, ".diff-results-container")


### PR DESCRIPTION

![Screen recording of new options display](https://user-images.githubusercontent.com/120878/90325343-a3a64680-df37-11ea-9c89-5f8a7917cd29.gif)


This displays the options the version of the app was generated with. This will be especially useful in an upcoming PRs that will allow the user to pick which variant of a phoenix version they want to compare (no options, `--live`, `--umbrella`).

This version of the app is available to play with here: https://ar-phx-diff.herokuapp.com/.

I'm a bit rusty on my frontend skills, so if you see a way to simplify the HTML/CSS please let me know.