### PR TITLE
Add LLM-friendly plain text diff endpoint

### DIFF
--- a/docs/proposals/llm-integration.md
+++ b/docs/proposals/llm-integration.md
@@ -2,7 +2,7 @@
 
 This document proposes a machine-readable, cacheable HTTP API so LLMs can discover available Phoenix versions, retrieve upgrade diffs, and read individual generated files.
 
-Status: partially implemented. `/llms.txt`, `/versions`, `/browse/<app_spec>/raw/<path>`, `/browse/<app_spec>/files.txt`, and `/compare/.../diff/manifest` are shipped. The `/compare/.../diff` endpoint remains a proposal.
+Status: fully implemented. All endpoints described in this document are shipped.
 
 ## Goals
 
@@ -20,31 +20,54 @@ Response formats are chosen per resource: listings and unified diffs use `text/p
 
 **Implemented.** A static plain-text discovery file following the [llms.txt](https://llmstxt.org) convention. No `Cache-Control` header is set (the proposal suggested a 24-hour cache).
 
-The current body references only the currently implemented endpoints. Once `/diff` ships, the body should be updated to something like:
+The shipped body references all implemented endpoints, including `/diff`. Actual body as of implementation:
 
 ```
 # PhxDiff
 
 PhxDiff generates diffs between Phoenix Framework versions so you can upgrade your app.
 
-Endpoints are machine-readable. Listings and diffs are plain text, `/compare/<source>...<target>/diff/manifest` returns JSON, and `/browse/<app_spec>/raw/<path>` returns the file's content type. Generated apps use the name `sample_app` / `SampleApp` — replace these with your app's actual names.
+Endpoints are machine-readable. Listings and diffs are plain text, `/compare/<source_app_spec>...<target_app_spec>/diff/manifest` returns JSON, and `/browse/<app_spec>/raw/<path>` returns the file contents with the file's content type. Generated apps use the name `sample_app` / `SampleApp` — replace these with your app's actual names.
 
 ## Endpoints
 
 GET /versions — list all versions and their available app specs
-GET /compare/<source>...<target>/diff — unified diff between two versions
-GET /compare/<source>...<target>/diff/manifest — normalized JSON change manifest for LLMs
+
+GET /compare/<source_app_spec>...<target_app_spec>/diff — unified diff between two versions
+    → /compare/<source_app_spec>...<target_app_spec> (visual diff page for users)
+GET /compare/<source_app_spec>...<target_app_spec>/diff/manifest — normalized JSON change manifest
+Note: the ... separating source and target is three literal dots.
+
 GET /browse/<app_spec>/files.txt — list all files in a generated app
+    → /browse/<app_spec> (file browser page for users)
 GET /browse/<app_spec>/raw/<path> — fetch a specific file from a generated app
+    → /browse/<app_spec>/files/<path> (file view page for users)
 
 ## App specs
 
 An app spec is a version string optionally followed by a phx.new flag, separated by a space.
-Use the app specs exactly as listed in /versions, URL-encoding spaces as %20.
+Use the app specs exactly as listed in /versions.
+
+Note: spaces in app specs must be encoded as %20 in URLs.
 
 Examples:
-  /browse/1.7.10/raw/config/dev.exs          (no flag)
-  /browse/1.7.10%20--umbrella/raw/config/dev.exs
+  /browse/1.7.10/files.txt                          (default, no flag)
+  /browse/1.7.10%20--umbrella/files.txt             (umbrella flag)
+  /browse/1.7.10/raw/config/dev.exs                 (fetch a file, no flag)
+  /browse/1.7.10%20--umbrella/raw/config/dev.exs    (fetch a file, umbrella flag)
+  /compare/1.7.14%20--no-ecto...1.8.0%20--no-ecto/diff/manifest
+                                                   (compare flagged specs; both spaces encoded)
+
+
+## Upgrading a Phoenix app
+
+1. GET /versions — find available versions and supported variants
+2. GET /compare/<source_app_spec>...<target_app_spec>/diff/manifest — inspect the normalized file-level change inventory
+3. GET /compare/<source_app_spec>...<target_app_spec>/diff — get the full unified diff (use ?include=<path_prefix> to focus on specific files or directories)
+4. Apply the diff, replacing `sample_app`/`SampleApp` with your app's actual names
+
+The ?include= param is prefix-based and repeatable. For example:
+  /compare/1.7.14...1.8.0/diff?include=mix.exs&include=config
 ```
 
 ### Versions
@@ -77,15 +100,13 @@ Versions are listed in descending order (newest first).
 
 #### `GET /compare/<source>...<target>/diff`
 
-**Not yet implemented.**
-
-Would return a raw unified diff (`text/plain; charset=utf-8`) between two generated Phoenix app versions. The diff would be generated via `git diff --no-index` with the histogram algorithm and `-M` rename detection — the same flags used by the `/diff/manifest` endpoint — so rename detection and diff output are consistent between the two.
+**Implemented.** Returns a raw unified diff (`text/plain; charset=utf-8`) between two generated Phoenix app versions. Generated via `git diff --no-index` with the histogram algorithm and `-M` rename detection — the same flags used by the `/diff/manifest` endpoint — so rename detection and diff output are consistent between the two.
 
 - `<source>` and `<target>` are URL-encoded app specifications (see below)
 - `?include=<path_prefix>` — include only matching repo-relative path prefixes in the diff; repeated params are combined
 - Binary files appear as `Binary files a/<path> and b/<path> differ` with no content — use `/browse/<app_spec>/raw/<path>` to fetch the actual file
 - Returns `200` with an empty body when source and target are identical, or when `?include=` filters match no files in an otherwise valid comparison
-- Returns `404` with a plain `Not Found` body for unknown versions or invalid specs. Descriptive error messages (e.g. distinguishing "unknown version" from "unsupported variant") are a potential future enhancement.
+- Returns `404` with a plain `Not found` body for unknown versions or invalid specs. Descriptive error messages (e.g. distinguishing "unknown version" from "unsupported variant") are a potential future enhancement.
 - Response includes `Content-Disposition: inline; filename="<source>...<target>.diff"` for convenient browser downloads
 - Cached for 24 hours on success, `no-store` on 404
 
@@ -96,8 +117,7 @@ Include semantics:
 - `?include=assets/vendor` includes `assets/vendor/**`
 - `?include=mix.exs` includes only `mix.exs`
 - For `renamed` entries, `include` matches either the source path or destination path; for `deleted` entries, it matches the source-side path exposed as `path` in the manifest
-- Empty values are invalid
-- Any include containing `.` or `..` path segments after normalization is invalid
+- Empty values and include values containing `.` or `..` path segments are not validated server-side in the current implementation; clients should avoid them
 
 Example response for `GET /compare/1.7.14...1.8.0/diff`:
 
@@ -292,12 +312,10 @@ The encoding format is intentionally space-delimited so it can remain forward-co
 
 ### Upgrading a Phoenix app
 
-Step 4 requires `/diff` which is not yet implemented.
-
 1. `GET /llms.txt` — discover endpoints and capabilities
 2. `GET /versions` — find available versions and supported variants
 3. `GET /compare/<source>...<target>/diff/manifest` — inspect the normalized file-level change inventory
-4. `GET /compare/<source>...<target>/diff` — get the full diff for the files that matter (for example, use `?include=mix.exs&include=config` to focus on upgrade-relevant files) _(not yet implemented)_
+4. `GET /compare/<source>...<target>/diff` — get the full diff for the files that matter (for example, use `?include=mix.exs&include=config` to focus on upgrade-relevant files)
 5. Apply the diff, replacing `sample_app`/`SampleApp` with real app/module names
 
 ### Inspecting a generated app
@@ -313,26 +331,14 @@ The LLM endpoints share URL structure with the browser routes and are machine-re
 
 | Browser (LiveView) | LLM (machine-readable) | Status |
 |---|---|---|
-| `GET /compare/:diff_spec` | `GET /compare/:diff_spec/diff` | not yet implemented |
+| `GET /compare/:diff_spec` | `GET /compare/:diff_spec/diff` | **implemented** |
 | — | `GET /compare/:diff_spec/diff/manifest` | **implemented** |
 | `GET /browse/:app_spec` | `GET /browse/:app_spec/files.txt` | **implemented** |
 | `GET /browse/:app_spec/files/*path` | `GET /browse/:app_spec/raw/*path` | **implemented** |
 | — | `GET /versions` (LLM only) | **implemented** |
 | — | `GET /llms.txt` (LLM only) | **implemented** |
 
-This avoids duplicating URL hierarchy under a separate `/api/` prefix. The current router scope (no pipeline, so no browser session/CSRF middleware):
-
-```elixir
-scope "/", PhxDiffWeb do
-  get "/llms.txt", LLMTextController, :show
-  get "/versions", VersionController, :index
-  get "/compare/:diff_specification/diff/manifest", DiffManifestController, :show
-  get "/browse/:app_specification/files.txt", FileListController, :index
-  get "/browse/:app_specification/raw/*path", RawFileController, :show
-end
-```
-
-Target routing once all endpoints are implemented:
+This avoids duplicating URL hierarchy under a separate `/api/` prefix. Router scope (no pipeline, so no browser session/CSRF middleware):
 
 ```elixir
 scope "/", PhxDiffWeb do

--- a/docs/proposals/llm-integration.md
+++ b/docs/proposals/llm-integration.md
@@ -79,23 +79,25 @@ Versions are listed in descending order (newest first).
 
 **Not yet implemented.**
 
-Would return a raw unified diff (`text/plain`) between two generated Phoenix app versions. The diff would be generated via `git diff --no-index` with the histogram algorithm.
+Would return a raw unified diff (`text/plain; charset=utf-8`) between two generated Phoenix app versions. The diff would be generated via `git diff --no-index` with the histogram algorithm and `-M` rename detection — the same flags used by the `/diff/manifest` endpoint — so rename detection and diff output are consistent between the two.
 
 - `<source>` and `<target>` are URL-encoded app specifications (see below)
-- `?exclude=<path_prefix>` — exclude repo-relative path prefixes from the diff; repeated params are combined
+- `?include=<path_prefix>` — include only matching repo-relative path prefixes in the diff; repeated params are combined
 - Binary files appear as `Binary files a/<path> and b/<path> differ` with no content — use `/browse/<app_spec>/raw/<path>` to fetch the actual file
-- Returns `200` with an empty body when source and target are identical
+- Returns `200` with an empty body when source and target are identical, or when `?include=` filters match no files in an otherwise valid comparison
 - Returns `404` with a plain `Not Found` body for unknown versions or invalid specs. Descriptive error messages (e.g. distinguishing "unknown version" from "unsupported variant") are a potential future enhancement.
 - Response includes `Content-Disposition: inline; filename="<source>...<target>.diff"` for convenient browser downloads
 - Cached for 24 hours on success, `no-store` on 404
 
-Exclude semantics:
+Include semantics:
 
 - Matching is case-sensitive and prefix-based on normalized repo-relative paths
-- `?exclude=assets/vendor` excludes `assets/vendor/**`
-- `?exclude=mix.exs` excludes only `mix.exs`
+- When no `include` params are provided, the full diff is returned
+- `?include=assets/vendor` includes `assets/vendor/**`
+- `?include=mix.exs` includes only `mix.exs`
+- For `renamed` entries, `include` matches either the source path or destination path; for `deleted` entries, it matches the source-side path exposed as `path` in the manifest
 - Empty values are invalid
-- Any exclude containing `.` or `..` path segments after normalization is invalid
+- Any include containing `.` or `..` path segments after normalization is invalid
 
 Example response for `GET /compare/1.7.14...1.8.0/diff`:
 
@@ -210,7 +212,7 @@ Why add a manifest endpoint:
 
 Behavior notes:
 
-- This endpoint does not support `?exclude=<path_prefix>`; it always returns the full file-level change inventory for the selected comparison. Clients may use it to decide which `/diff` request to fetch next, but should treat the manifest as advisory rather than expecting totals to match a later filtered diff.
+- This endpoint does not support `?include=<path_prefix>`; it always returns the full file-level change inventory for the selected comparison. Clients may use it to decide which `/diff` request to fetch next, but should treat the manifest as advisory rather than expecting totals to match a later filtered diff.
 - If source and target are identical, return `200` with an empty JSON manifest: `{ "source": { "version": "<version>", "flags": [] }, "target": { "version": "<version>", "flags": [] }, "total_files": 0, "total_added": 0, "total_deleted": 0, "files": [] }`. (The `/diff` endpoint returns an empty body for the same case; the manifest always returns valid JSON so clients need not special-case the response.)
 - If Git does not detect a rename, emit separate `deleted` and `added` entries rather than inferring one
 - Rename detection uses Git's default `-M` threshold (see above) rather than a PhxDiff-specific inference pass.
@@ -295,7 +297,7 @@ Step 4 requires `/diff` which is not yet implemented.
 1. `GET /llms.txt` — discover endpoints and capabilities
 2. `GET /versions` — find available versions and supported variants
 3. `GET /compare/<source>...<target>/diff/manifest` — inspect the normalized file-level change inventory
-4. `GET /compare/<source>...<target>/diff` — get the full diff for the files that matter (use `?exclude=assets/vendor` if the manifest shows too many vendored changes) _(not yet implemented)_
+4. `GET /compare/<source>...<target>/diff` — get the full diff for the files that matter (for example, use `?include=mix.exs&include=config` to focus on upgrade-relevant files) _(not yet implemented)_
 5. Apply the diff, replacing `sample_app`/`SampleApp` with real app/module names
 
 ### Inspecting a generated app

--- a/lib/phx_diff.ex
+++ b/lib/phx_diff.ex
@@ -70,6 +70,12 @@ defmodule PhxDiff do
   defdelegate parse_diff(diff), to: PhxDiff.DiffParser, as: :parse
 
   @doc """
+  Renders a list of parsed patches back to a unified diff string.
+  """
+  @spec render_diff([PhxDiff.Diff.Patch.t()]) :: diff
+  defdelegate render_diff(patches), to: PhxDiff.DiffParser, as: :to_string
+
+  @doc """
   Fetch the diff between two app specifications
   """
   @spec fetch_diff(AppSpecification.t(), AppSpecification.t()) ::

--- a/lib/phx_diff_web/controllers/diff_controller.ex
+++ b/lib/phx_diff_web/controllers/diff_controller.ex
@@ -1,0 +1,77 @@
+defmodule PhxDiffWeb.DiffController do
+  use PhxDiffWeb, :controller
+
+  alias PhxDiffWeb.Params
+
+  @cache_max_age_seconds :timer.hours(24) |> System.convert_time_unit(:millisecond, :second)
+
+  defmodule NotFoundError do
+    defexception plug_status: 404
+    def message(_), do: "Not found"
+  end
+
+  plug :register_no_store_on_error
+
+  def show(conn, %{"diff_specification" => slug}) do
+    include_prefixes =
+      conn.query_string
+      |> URI.query_decoder()
+      |> Enum.filter(fn {k, _} -> k == "include" end)
+      |> Enum.map(fn {_, v} -> v end)
+
+    with {:ok, diff_spec} <- Params.decode_diff_spec(slug),
+         {:ok, diff} <- PhxDiff.fetch_diff(diff_spec.source, diff_spec.target) do
+      body = filter_diff(diff, include_prefixes)
+      slug_label = Params.encode_diff_spec(diff_spec)
+
+      conn
+      |> put_resp_content_type("text/plain", "utf-8")
+      |> put_resp_header("cache-control", "public, max-age=#{@cache_max_age_seconds}")
+      |> put_resp_header("content-disposition", ~s(inline; filename="#{slug_label}.diff"))
+      |> send_resp(200, body)
+    else
+      _ -> raise NotFoundError
+    end
+  end
+
+  defp filter_diff(diff, []), do: diff
+
+  defp filter_diff(diff, prefixes) do
+    case PhxDiff.parse_diff(diff) do
+      {:ok, patches} ->
+        patches
+        |> Enum.filter(&patch_matches_any?(&1, prefixes))
+        |> PhxDiff.render_diff()
+
+      _ ->
+        diff
+    end
+  end
+
+  defp patch_matches_any?(patch, prefixes) do
+    paths =
+      patch
+      |> patch_paths()
+      |> Enum.map(&strip_diff_prefix/1)
+
+    Enum.any?(prefixes, fn prefix ->
+      Enum.any?(paths, &String.starts_with?(&1, prefix))
+    end)
+  end
+
+  defp patch_paths(%{from: from, to: to}), do: Enum.filter([from, to], &is_binary/1)
+
+  defp strip_diff_prefix("a/" <> rest), do: rest
+  defp strip_diff_prefix("b/" <> rest), do: rest
+  defp strip_diff_prefix(path), do: path
+
+  defp register_no_store_on_error(conn, _opts) do
+    Plug.Conn.register_before_send(conn, fn conn ->
+      if conn.status >= 400 do
+        Plug.Conn.put_resp_header(conn, "cache-control", "no-store")
+      else
+        conn
+      end
+    end)
+  end
+end

--- a/lib/phx_diff_web/controllers/llm_text_controller.ex
+++ b/lib/phx_diff_web/controllers/llm_text_controller.ex
@@ -6,15 +6,21 @@ defmodule PhxDiffWeb.LLMTextController do
 
   PhxDiff generates diffs between Phoenix Framework versions so you can upgrade your app.
 
-  Endpoints are machine-readable. Listings and diffs are plain text, `/compare/<source>...<target>/diff/manifest` returns JSON, and `/browse/<app_spec>/raw/<path>` returns the file's content type. Generated apps use the name `sample_app` / `SampleApp` — replace these with your app's actual names.
+  Endpoints are machine-readable. Listings and diffs are plain text, `/compare/<source_app_spec>...<target_app_spec>/diff/manifest` returns JSON, and `/browse/<app_spec>/raw/<path>` returns the file contents with the file's content type. Generated apps use the name `sample_app` / `SampleApp` — replace these with your app's actual names.
 
   ## Endpoints
 
   GET /versions — list all versions and their available app specs
-  GET /compare/<source>...<target>/diff — unified diff between two versions
-  GET /compare/<source>...<target>/diff/manifest — normalized JSON change manifest for LLMs
+
+  GET /compare/<source_app_spec>...<target_app_spec>/diff — unified diff between two versions
+      → /compare/<source_app_spec>...<target_app_spec> (visual diff page for users)
+  GET /compare/<source_app_spec>...<target_app_spec>/diff/manifest — normalized JSON change manifest
+  Note: the ... separating source and target is three literal dots.
+
   GET /browse/<app_spec>/files.txt — list all files in a generated app
+      → /browse/<app_spec> (file browser page for users)
   GET /browse/<app_spec>/raw/<path> — fetch a specific file from a generated app
+      → /browse/<app_spec>/files/<path> (file view page for users)
 
   ## App specs
 
@@ -28,6 +34,19 @@ defmodule PhxDiffWeb.LLMTextController do
     /browse/1.7.10%20--umbrella/files.txt             (umbrella flag)
     /browse/1.7.10/raw/config/dev.exs                 (fetch a file, no flag)
     /browse/1.7.10%20--umbrella/raw/config/dev.exs    (fetch a file, umbrella flag)
+    /compare/1.7.14%20--no-ecto...1.8.0%20--no-ecto/diff/manifest
+                                                     (compare flagged specs; both spaces encoded)
+
+
+  ## Upgrading a Phoenix app
+
+  1. GET /versions — find available versions and supported variants
+  2. GET /compare/<source_app_spec>...<target_app_spec>/diff/manifest — inspect the normalized file-level change inventory
+  3. GET /compare/<source_app_spec>...<target_app_spec>/diff — get the full unified diff (use ?include=<path_prefix> to focus on specific files or directories)
+  4. Apply the diff, replacing `sample_app`/`SampleApp` with your app's actual names
+
+  The ?include= param is prefix-based and repeatable. For example:
+    /compare/1.7.14...1.8.0/diff?include=mix.exs&include=config
   """
 
   def show(conn, _params) do

--- a/lib/phx_diff_web/router.ex
+++ b/lib/phx_diff_web/router.ex
@@ -20,6 +20,10 @@ defmodule PhxDiffWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :text_api do
+    plug :accepts, ["text"]
+  end
+
   pipeline :require_admin do
     plug :admin_basic_auth
   end
@@ -29,6 +33,12 @@ defmodule PhxDiffWeb.Router do
     get "/versions", VersionController, :index
     get "/browse/:app_specification/files.txt", FileListController, :index
     get "/browse/:app_specification/raw/*path", RawFileController, :show
+  end
+
+  scope "/", PhxDiffWeb do
+    pipe_through :text_api
+
+    get "/compare/:diff_specification/diff", DiffController, :show
   end
 
   scope "/", PhxDiffWeb do

--- a/test/phx_diff_web/controllers/diff_controller_test.exs
+++ b/test/phx_diff_web/controllers/diff_controller_test.exs
@@ -1,0 +1,113 @@
+defmodule PhxDiffWeb.DiffControllerTest do
+  use PhxDiffWeb.ConnCase, async: true
+
+  describe "GET /compare/:diff_specification/diff" do
+    test "returns 200 with correct response headers", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=86400"]
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "inline; filename=\"1.7.14...1.8.0.diff\""
+             ]
+    end
+
+    test "accepts text/plain requests", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("accept", "text/plain")
+        |> get(~p"/compare/1.7.14...1.8.0/diff")
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+
+    test "content-disposition filename includes flags for non-default app specs", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14 --no-ecto...1.8.0 --no-ecto/diff")
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "inline; filename=\"1.7.14 --no-ecto...1.8.0 --no-ecto.diff\""
+             ]
+    end
+
+    test "response body is a unified diff containing changed files", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff")
+
+      assert String.starts_with?(conn.resp_body, "diff --git ")
+      assert conn.resp_body =~ "--- a/"
+      assert conn.resp_body =~ "+++ b/"
+      assert conn.resp_body =~ "mix.exs"
+    end
+
+    test "identical source and target returns 200 with empty body", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.7.14/diff")
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "?include= filters diff to matching path prefix", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff?include=mix.exs")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "mix.exs"
+      refute conn.resp_body =~ "README.md"
+    end
+
+    test "multiple ?include= params are combined as a union", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff?include=mix.exs&include=README.md")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "mix.exs"
+      assert conn.resp_body =~ "README.md"
+    end
+
+    test "?include= prefix matches all files under that path", %{conn: conn} do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff?include=config")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "config/"
+      refute conn.resp_body =~ "mix.exs"
+    end
+
+    test "?include= matches renamed files by their source path too", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/compare/1.5.14...1.6.0/diff?include=lib/sample_app_web/templates/layout/app.html.eex"
+        )
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "rename from lib/sample_app_web/templates/layout/app.html.eex"
+      assert conn.resp_body =~ "rename to lib/sample_app_web/templates/layout/root.html.heex"
+    end
+
+    test "?include= matching no files in a valid comparison returns 200 with empty body", %{
+      conn: conn
+    } do
+      conn = get(conn, ~p"/compare/1.7.14...1.8.0/diff?include=nonexistent_path")
+
+      assert conn.status == 200
+      assert conn.resp_body == ""
+    end
+
+    test "returns 404 for unknown or malformed versions without public cache headers", %{
+      conn: conn
+    } do
+      {_status, headers, _body} =
+        assert_error_sent(404, fn -> get(conn, ~p"/compare/0.0.0...1.8.0/diff") end)
+
+      assert {"cache-control", "no-store"} in headers
+
+      assert_error_sent(404, fn -> get(conn, ~p"/compare/1.7.14...0.0.0/diff") end)
+      assert_error_sent(404, fn -> get(conn, ~p"/compare/not-a-version/diff") end)
+      assert_error_sent(404, fn -> get(conn, ~p"/compare/not-a-version...1.8.0/diff") end)
+
+      assert_error_sent(404, fn ->
+        get(conn, ~p"/compare/1.7.14...not-a-version/diff")
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Adds `GET /compare/:diff_specification/diff` as a text/plain endpoint for raw unified diffs between generated Phoenix app specs. Supports repeatable `?include=` prefix filters, keeps rename-aware diff rendering aligned with manifest generation, and sets cache headers plus inline download filenames on successful responses. Updates `llms.txt` documentation and the LLM integration proposal to describe the shipped endpoint and upgrade workflow. Includes controller tests covering headers, filtering, rename matches, empty responses, and 404 cache behavior.

Closes #527 