### PR TITLE
Fix llms.txt character encoding in Firefox

### DIFF
--- a/lib/phx_diff_web/controllers/llm_text_controller.ex
+++ b/lib/phx_diff_web/controllers/llm_text_controller.ex
@@ -51,7 +51,7 @@ defmodule PhxDiffWeb.LLMTextController do
 
   def show(conn, _params) do
     conn
-    |> put_resp_content_type("text/plain", nil)
+    |> put_resp_content_type("text/plain", "utf-8")
     |> send_resp(200, @body)
   end
 end

--- a/test/phx_diff_web/controllers/llm_text_controller_test.exs
+++ b/test/phx_diff_web/controllers/llm_text_controller_test.exs
@@ -6,7 +6,7 @@ defmodule PhxDiffWeb.LLMTextControllerTest do
       conn = get(conn, ~p"/llms.txt")
 
       assert conn.status == 200
-      assert get_resp_header(conn, "content-type") == ["text/plain"]
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
       assert conn.resp_body =~ "PhxDiff"
       assert conn.resp_body =~ "/versions"
     end


### PR DESCRIPTION
## Summary

- `put_resp_content_type("text/plain", nil)` omitted the charset from the `Content-Type` header
- Firefox defaulted to Latin-1, mangling the UTF-8 `→` arrow characters in the response body
- Changed `nil` to `"utf-8"` so the header reads `text/plain; charset=utf-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)