### PR TITLE
Apply Phoenix 1.7.x generator updates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,7 @@ config :phx_diff,
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.25.9",
-  default: [
+  phx_diff: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("../assets", __DIR__),
@@ -35,7 +35,7 @@ config :esbuild,
 # Configure tailwind (the version is required)
 config :tailwind,
   version: "4.1.12",
-  default: [
+  phx_diff: [
     args: ~w(
       --input=assets/css/app.css
       --output=priv/static/assets/app.css

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -13,9 +13,9 @@ config :phx_diff, PhxDiffWeb.Endpoint,
   debug_errors: true,
   secret_key_base: "yZ51VROLXAgAiopHqa3JgxK2SDFp9BymmYjkVs1EjKhsJUbPJeg6WZIIqyp0C5Lk",
   watchers: [
-    # Start the esbuild watcher by calling Esbuild.install_and_run(:default, args)
-    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
-    tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
+    # Start the esbuild watcher by calling Esbuild.install_and_run(:phx_diff, args)
+    esbuild: {Esbuild, :install_and_run, [:phx_diff, ~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [:phx_diff, ~w(--watch)]}
   ]
 
 # ## SSL Support

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -46,7 +46,7 @@ config :phx_diff, PhxDiffWeb.Endpoint,
 config :phx_diff, PhxDiffWeb.Endpoint,
   live_reload: [
     patterns: [
-      ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
       ~r"lib/phx_diff_web/(controllers|live|components)/.*(ex|heex)$"
     ]

--- a/lib/phx_diff/application.ex
+++ b/lib/phx_diff/application.ex
@@ -14,14 +14,12 @@ defmodule PhxDiff.Application do
     # List all child processes to be supervised
     children = [
       PhxDiff,
-      # Start the Telemetry supervisor
       PhxDiffWeb.Telemetry,
-      # Start the PubSub system
       {Phoenix.PubSub, name: PhxDiff.PubSub},
-      # Start the endpoint when the application starts
-      PhxDiffWeb.Endpoint
       # Start a worker by calling: PhxDiff.Worker.start_link(arg)
       # {PhxDiff.Worker, arg},
+      # Start to serve requests, typically the last entry
+      PhxDiffWeb.Endpoint
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/phx_diff_web/components/core_components.ex
+++ b/lib/phx_diff_web/components/core_components.ex
@@ -461,9 +461,9 @@ defmodule PhxDiffWeb.CoreComponents do
     # with our gettext backend as first argument. Translations are
     # available in the errors.po file (as we use the "errors" domain).
     if count = opts[:count] do
-      Gettext.dngettext(SampleAppWeb.Gettext, "errors", msg, msg, count, opts)
+      Gettext.dngettext(PhxDiffWeb.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(SampleAppWeb.Gettext, "errors", msg, opts)
+      Gettext.dgettext(PhxDiffWeb.Gettext, "errors", msg, opts)
     end
   end
 

--- a/lib/phx_diff_web/telemetry.ex
+++ b/lib/phx_diff_web/telemetry.ex
@@ -44,6 +44,7 @@ defmodule PhxDiffWeb.Telemetry do
         end,
         unit: {:native, :millisecond}
       ),
+      sum("phoenix.socket_drain.count"),
 
       # VM Metrics
       summary("vm.memory.total", unit: {:byte, :kilobyte}),

--- a/mix.exs
+++ b/mix.exs
@@ -116,8 +116,8 @@ defmodule PhxDiff.MixProject do
         "cmd --cd assets yarn install"
       ],
       "assets.deploy": [
-        "tailwind default --minify",
-        "esbuild default --minify",
+        "tailwind phx_diff --minify",
+        "esbuild phx_diff --minify",
         "phx.digest"
       ]
     ]


### PR DESCRIPTION
## Summary
- Fix `SampleAppWeb.Gettext` → `PhxDiffWeb.Gettext` in `CoreComponents.translate_error/1`
- Add `phoenix.socket_drain.count` telemetry metric (added in Phoenix 1.7.20)
- Rename esbuild/tailwind profiles from `:default` to `:phx_diff` (convention since 1.7.8)
- Exclude uploads directory from live reload pattern (convention since 1.7.3)
- Clean up Application supervision tree comments and child ordering (convention since 1.7.8)

## Test plan
- [ ] Verify app compiles without warnings
- [ ] Verify assets build correctly with renamed profiles (`mix assets.deploy`)
- [ ] Verify live reload still works in dev
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)