### PR TITLE
Move preferred_cli_env to def cli to fix Mix 1.19 deprecation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,13 +11,18 @@ defmodule PhxDiff.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      preferred_cli_env: [
-        ci: :test
-      ],
       releases: releases(),
       default_release: :phx_diff,
       dialyzer: dialyzer(System.get_env()),
       docs: docs()
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        ci: :test
+      ]
     ]
   end
 


### PR DESCRIPTION
## Summary

- Moves `preferred_cli_env: [ci: :test]` out of `def project` and into a new `def cli` function
- Renames the key from `preferred_cli_env` to `preferred_envs` as required by Mix 1.19+
- Fixes the Dependabot lockfile update failure caused by this deprecation warning being treated as an error

## Test plan
- [ ] Verify `mix ci` still runs in the `:test` environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)