### PR TITLE
Upgrade BEAM toolchain

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "hexpm/elixir:1.18.3-erlang-27.3.4-ubuntu-noble-20250415.1",
+  "image": "hexpm/elixir:1.19.5-erlang-28.5-ubuntu-noble-20260410",
   "postCreateCommand": "apt-get update && apt-get install -y build-essential git inotify-tools",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: erlef/setup-beam@v1
         id: beam
         with:
-          otp-version: '27.3'
-          elixir-version: '1.18.3'
+          otp-version: '28.5'
+          elixir-version: '1.19.5'
       - name: Restore the build cache
         uses: actions/cache/restore@v5
         id: build_cache
@@ -73,8 +73,8 @@ jobs:
       # Download phoenix so we yarn install works correctly
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '27.3'
-          elixir-version: '1.18.3'
+          otp-version: '28.5'
+          elixir-version: '1.19.5'
       - uses: actions/cache@v5
         with:
           path: |

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
 [tools]
-erlang = "27.1"
-elixir = "1.17.3-otp-27"
+erlang = "28.5"
+elixir = "1.19.5-otp-28"
 node = "18.20.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20220801-slim - for the release image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm-20260421-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.13.3-erlang-24.3.2-debian-bullseye-20210902-slim
+#   - Ex: hexpm/elixir:1.19.5-erlang-28.5-debian-bookworm-20260421-slim
 #
-ARG ELIXIR_VERSION=1.18.3
-ARG OTP_VERSION=27.3.4
-ARG DEBIAN_VERSION=bookworm-20250428-slim
+ARG ELIXIR_VERSION=1.19.5
+ARG OTP_VERSION=28.5
+ARG DEBIAN_VERSION=bookworm-20260421-slim
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhxDiff.MixProject do
     [
       app: :phx_diff,
       version: "0.1.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/test/support/capture_json_log.ex
+++ b/test/support/capture_json_log.ex
@@ -3,6 +3,10 @@ defmodule PhxDiff.CaptureJSONLog do
   Captures and parses JSON log output
   """
 
+  # TODO: Rework this once Elixir 1.20 lands with the {:formatter, ...} capture_log option.
+  @dialyzer {:nowarn_function, capture_json_log: 1}
+  @dialyzer {:nowarn_function, parse_json_logs: 1}
+  @spec capture_json_log((-> any())) :: [map()]
   def capture_json_log(function) when is_function(function) do
     ExUnit.CaptureLog.capture_log(
       [

--- a/test/support/capture_json_log.ex
+++ b/test/support/capture_json_log.ex
@@ -3,7 +3,7 @@ defmodule PhxDiff.CaptureJSONLog do
   Captures and parses JSON log output
   """
 
-  # TODO: Rework this once Elixir 1.20 lands with the {:formatter, ...} capture_log option.
+  # Revisit when Elixir exposes capture_log formatter options directly.
   @dialyzer {:nowarn_function, capture_json_log: 1}
   @dialyzer {:nowarn_function, parse_json_logs: 1}
   @spec capture_json_log((-> any())) :: [map()]


### PR DESCRIPTION
Upgrades the app to Elixir 1.19.5 on Erlang/OTP 28.5 across local mise config, CI, Docker, and the devcontainer.

Keeps the production Docker image on Debian using `hexpm/elixir:1.19.5-erlang-28.5-debian-bookworm-20260421-slim`.

Updates the app Elixir requirement to `~> 1.19` and adds a focused Dialyzer TODO/suppression for the JSON log capture helper until Elixir 1.20 exposes the formatter option.

Validated with `mise exec -- mix ci`, `mise exec -- mix format --check-formatted`, and `git diff --check`.
