### PR TITLE
Extract Store behaviour for AppRepo with FileSystem implementation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,7 @@ config :phx_diff, PhxDiffWeb.Endpoint,
   live_view: [signing_salt: "NpCfQvr9hr3z/LRwF8WZL5LmKP0wC9e3"]
 
 config :phx_diff,
+  app_repo_store: PhxDiff.Diffs.AppRepo.Store.FileSystem,
   github_sample_app_base_url:
     "https://github.com/phoenix-diff/phoenix-diff/tree/master/priv/data/sample-app"
 

--- a/docs/coding-practices.md
+++ b/docs/coding-practices.md
@@ -39,6 +39,29 @@ dialyzer
 - Return `{:ok, value}` / `{:error, reason}` for fallible operations.
 - Name boolean functions with a `?` suffix; bang functions with `!`.
 
+## Configuration
+
+- Access application environment values through the config adapter layer, not directly from feature modules.
+- Core modules should call `PhxDiff.Config`; web modules should call `PhxDiffWeb.Config`.
+- Read OS environment variables in `config/runtime.exs`, write them into the application environment, then expose them through the config module.
+- Put application environment reads and default config lookups in the matching `DefaultAdapter` module.
+- Store default application config values in `config/config.exs` instead of hard-coding fallback values at call sites.
+- Add new adapter callbacks when feature code needs a new configurable value so tests can swap config with Mox.
+- To stub core config in a test, import Mox, use `PhxDiff.MockedConfigCase` when the case template does not already include it, and stub the mock adapter:
+
+```elixir
+use ExUnit.Case, async: true
+use PhxDiff.MockedConfigCase
+
+import Mox
+
+test "uses a custom app repo path" do
+  stub(PhxDiff.Config.Mock, :app_repo_path, fn -> "/tmp/sample-apps" end)
+
+  assert PhxDiff.Config.app_repo_path() == "/tmp/sample-apps"
+end
+```
+
 ## Routing
 
 Use verified route sigils — never build URL strings manually:

--- a/lib/phx_diff/config.ex
+++ b/lib/phx_diff/config.ex
@@ -11,6 +11,12 @@ defmodule PhxDiff.Config do
   end
 
   @impl true
+  @spec app_repo_store() :: module()
+  def app_repo_store do
+    adapter().app_repo_store()
+  end
+
+  @impl true
   @spec app_generator_workspace_path() :: String.t()
   def app_generator_workspace_path do
     adapter().app_generator_workspace_path()

--- a/lib/phx_diff/config/adapter.ex
+++ b/lib/phx_diff/config/adapter.ex
@@ -2,6 +2,7 @@ defmodule PhxDiff.Config.Adapter do
   @moduledoc false
 
   @callback app_repo_path() :: String.t()
+  @callback app_repo_store() :: module()
   @callback app_generator_workspace_path() :: String.t()
   @callback github_sample_app_base_url() :: String.t()
 end

--- a/lib/phx_diff/config/default_adapter.ex
+++ b/lib/phx_diff/config/default_adapter.ex
@@ -7,6 +7,9 @@ defmodule PhxDiff.Config.DefaultAdapter do
   def app_repo_path, do: Application.app_dir(:phx_diff, "priv/data/sample-app")
 
   @impl true
+  def app_repo_store, do: Application.fetch_env!(:phx_diff, :app_repo_store)
+
+  @impl true
   def github_sample_app_base_url,
     do: Application.fetch_env!(:phx_diff, :github_sample_app_base_url)
 

--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -3,18 +3,10 @@ defmodule PhxDiff.Diffs.AppRepo do
 
   alias PhxDiff.AppSpecification
   alias PhxDiff.Diffs.AppRepo.AppGenerator
+  alias PhxDiff.Diffs.AppRepo.AppSpecPath
+  alias PhxDiff.Diffs.AppRepo.Store.FileSystem
 
   @type version :: PhxDiff.Diffs.version()
-
-  @args_to_path_mappings [
-    {[], "default"},
-    {["--live"], "live"},
-    {["--no-ecto"], "no-ecto"},
-    {["--no-live"], "no-live"},
-    {["--no-html"], "no-html"},
-    {["--binary-id"], "binary-id"},
-    {["--umbrella"], "umbrella"}
-  ]
 
   @spec all_versions() :: [version]
   def all_versions do
@@ -47,26 +39,22 @@ defmodule PhxDiff.Diffs.AppRepo do
   @spec fetch_app_path(AppSpecification.t()) ::
           {:ok, String.t()} | {:error, :invalid_version}
   def fetch_app_path(%AppSpecification{} = app_specification) do
-    if app_generated_for_specification?(app_specification) do
-      {:ok, app_path(app_specification)}
-    else
-      {:error, :invalid_version}
-    end
+    store().fetch_app_path(app_specification)
   end
 
   @spec list_sample_apps_for_version(Version.t()) :: [AppSpecification.t()]
   def list_sample_apps_for_version(%Version{} = version) do
-    PhxDiff.Config.app_repo_path()
-    |> Path.join("#{version}/*")
-    |> Path.wildcard()
-    |> Enum.map(&path_to_app_spec/1)
+    case store().list_app_specs_for_version(version) do
+      {:ok, app_specs} -> app_specs
+      {:error, :storage_unavailable} -> []
+    end
   end
 
   @spec generate_sample_app(AppSpecification.t()) ::
           {:ok, String.t()} | {:error, :unknown_version}
   def generate_sample_app(%AppSpecification{} = app_spec) do
     with {:ok, app_dir} <- AppGenerator.generate(app_spec) do
-      store_generated_app(app_spec, app_dir)
+      store().store_generated_app(app_spec, app_dir)
     end
   end
 
@@ -131,60 +119,17 @@ defmodule PhxDiff.Diffs.AppRepo do
   @spec get_github_sample_app_base_url(AppSpecification.t()) :: String.t()
   def get_github_sample_app_base_url(%AppSpecification{} = app_spec) do
     PhxDiff.Config.github_sample_app_base_url()
-    |> Path.join(app_spec_path(app_spec))
-  end
-
-  defp store_generated_app(app_spec, source_path) do
-    destination_path = app_path(app_spec)
-
-    File.rm_rf(destination_path)
-    File.mkdir_p!(destination_path)
-
-    File.rename!(source_path, destination_path)
-
-    {:ok, destination_path}
-  end
-
-  defp app_generated_for_specification?(app_spec) do
-    app_spec in app_specifications_for_pre_generated_apps()
-  end
-
-  defp app_path(app_spec) do
-    PhxDiff.Config.app_repo_path()
-    |> Path.join(app_spec_path(app_spec))
-  end
-
-  defp app_spec_path(%AppSpecification{} = app_spec) do
-    Path.join(
-      to_string(app_spec.phoenix_version),
-      phx_new_arguments_to_path(app_spec.phx_new_arguments)
-    )
-  end
-
-  for {args, path} <- @args_to_path_mappings do
-    defp phx_new_arguments_to_path(unquote(args)), do: unquote(path)
-  end
-
-  for {args, path} <- @args_to_path_mappings do
-    defp phx_new_arguments_from_path(unquote(path)), do: unquote(args)
+    |> Path.join(AppSpecPath.path(app_spec))
   end
 
   defp app_specifications_for_pre_generated_apps do
-    PhxDiff.Config.app_repo_path()
-    |> Path.join("*/*")
-    |> Path.wildcard()
-    |> Enum.map(&path_to_app_spec/1)
+    case store().list_app_specs() do
+      {:ok, app_specs} -> app_specs
+      {:error, :storage_unavailable} -> []
+    end
   end
 
-  defp path_to_app_spec(path) do
-    path
-    |> Path.relative_to(PhxDiff.Config.app_repo_path())
-    |> Path.split()
-    |> then(fn [serialized_version, serialized_arguments] ->
-      %AppSpecification{
-        phoenix_version: Version.parse!(serialized_version),
-        phx_new_arguments: phx_new_arguments_from_path(serialized_arguments)
-      }
-    end)
+  defp store do
+    Application.get_env(:phx_diff, :app_repo_store, FileSystem)
   end
 end

--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -4,7 +4,6 @@ defmodule PhxDiff.Diffs.AppRepo do
   alias PhxDiff.AppSpecification
   alias PhxDiff.Diffs.AppRepo.AppGenerator
   alias PhxDiff.Diffs.AppRepo.AppSpecPath
-  alias PhxDiff.Diffs.AppRepo.Store.FileSystem
 
   @type version :: PhxDiff.Diffs.version()
 
@@ -129,7 +128,5 @@ defmodule PhxDiff.Diffs.AppRepo do
     end
   end
 
-  defp store do
-    Application.get_env(:phx_diff, :app_repo_store, FileSystem)
-  end
+  defp store, do: PhxDiff.Config.app_repo_store()
 end

--- a/lib/phx_diff/diffs/app_repo/app_spec_path.ex
+++ b/lib/phx_diff/diffs/app_repo/app_spec_path.ex
@@ -1,0 +1,43 @@
+defmodule PhxDiff.Diffs.AppRepo.AppSpecPath do
+  @moduledoc false
+
+  alias PhxDiff.AppSpecification
+
+  @args_to_path_mappings [
+    {[], "default"},
+    {["--live"], "live"},
+    {["--no-ecto"], "no-ecto"},
+    {["--no-live"], "no-live"},
+    {["--no-html"], "no-html"},
+    {["--binary-id"], "binary-id"},
+    {["--umbrella"], "umbrella"}
+  ]
+
+  @spec path(AppSpecification.t()) :: String.t()
+  def path(%AppSpecification{} = app_spec) do
+    Path.join(
+      to_string(app_spec.phoenix_version),
+      phx_new_arguments_to_path(app_spec.phx_new_arguments)
+    )
+  end
+
+  @spec from_path(String.t()) :: AppSpecification.t()
+  def from_path(path) do
+    path
+    |> Path.split()
+    |> then(fn [serialized_version, serialized_arguments] ->
+      %AppSpecification{
+        phoenix_version: Version.parse!(serialized_version),
+        phx_new_arguments: phx_new_arguments_from_path(serialized_arguments)
+      }
+    end)
+  end
+
+  for {args, path} <- @args_to_path_mappings do
+    defp phx_new_arguments_to_path(unquote(args)), do: unquote(path)
+  end
+
+  for {args, path} <- @args_to_path_mappings do
+    defp phx_new_arguments_from_path(unquote(path)), do: unquote(args)
+  end
+end

--- a/lib/phx_diff/diffs/app_repo/store.ex
+++ b/lib/phx_diff/diffs/app_repo/store.ex
@@ -1,0 +1,15 @@
+defmodule PhxDiff.Diffs.AppRepo.Store do
+  @moduledoc false
+
+  alias PhxDiff.AppSpecification
+
+  @type fetch_error :: :invalid_version | :storage_unavailable
+  @type store_error :: :storage_unavailable
+
+  @callback list_app_specs() :: {:ok, [AppSpecification.t()]} | {:error, :storage_unavailable}
+  @callback list_app_specs_for_version(Version.t()) ::
+              {:ok, [AppSpecification.t()]} | {:error, :storage_unavailable}
+  @callback fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, fetch_error}
+  @callback store_generated_app(AppSpecification.t(), String.t()) ::
+              {:ok, String.t()} | {:error, store_error}
+end

--- a/lib/phx_diff/diffs/app_repo/store/file_system.ex
+++ b/lib/phx_diff/diffs/app_repo/store/file_system.ex
@@ -1,0 +1,64 @@
+defmodule PhxDiff.Diffs.AppRepo.Store.FileSystem do
+  @moduledoc false
+
+  @behaviour PhxDiff.Diffs.AppRepo.Store
+
+  alias PhxDiff.AppSpecification
+  alias PhxDiff.Diffs.AppRepo.AppSpecPath
+
+  @impl true
+  def list_app_specs do
+    specs =
+      PhxDiff.Config.app_repo_path()
+      |> Path.join("*/*")
+      |> Path.wildcard()
+      |> Enum.map(&path_to_app_spec/1)
+
+    {:ok, specs}
+  end
+
+  @impl true
+  def list_app_specs_for_version(%Version{} = version) do
+    specs =
+      PhxDiff.Config.app_repo_path()
+      |> Path.join("#{version}/*")
+      |> Path.wildcard()
+      |> Enum.map(&path_to_app_spec/1)
+
+    {:ok, specs}
+  end
+
+  @impl true
+  def fetch_app_path(%AppSpecification{} = app_spec) do
+    with {:ok, app_specs} <- list_app_specs() do
+      if app_spec in app_specs do
+        {:ok, app_path(app_spec)}
+      else
+        {:error, :invalid_version}
+      end
+    end
+  end
+
+  @impl true
+  def store_generated_app(%AppSpecification{} = app_spec, source_path) do
+    destination_path = app_path(app_spec)
+
+    File.rm_rf(destination_path)
+    File.mkdir_p!(destination_path)
+
+    File.rename!(source_path, destination_path)
+
+    {:ok, destination_path}
+  end
+
+  defp app_path(app_spec) do
+    PhxDiff.Config.app_repo_path()
+    |> Path.join(AppSpecPath.path(app_spec))
+  end
+
+  defp path_to_app_spec(path) do
+    path
+    |> Path.relative_to(PhxDiff.Config.app_repo_path())
+    |> AppSpecPath.from_path()
+  end
+end


### PR DESCRIPTION
## Summary
- Introduce a `PhxDiff.Diffs.AppRepo.Store` behaviour and extract the existing on-disk logic into `Store.FileSystem`, with a new `AppSpecPath` helper for path encoding/decoding.
- Wire the store selection through `PhxDiff.Config` (new `app_repo_store/0` adapter callback, defaulted in `config/config.exs`) so tests can swap stores via Mox.
- Document the config adapter pattern and the `PhxDiff.MockedConfigCase` Mox stubbing convention in `docs/coding-practices.md`.

## Test plan
- [x] `mix test`
- [x] `mix dialyzer`
- [x] `mix credo --strict --all`