### PR TITLE
Refine AppRepo store adapter facade

### DIFF
--- a/docs/coding-practices.md
+++ b/docs/coding-practices.md
@@ -13,6 +13,17 @@ Each namespace layer follows the same structure:
 - Public structs belong at or near the layer's namespace root (e.g. `PhxDiff.DiffManifest`, not `PhxDiff.Diffs.DiffManifest`).
 - Flow is strictly top-down: parents call children, never the reverse.
 
+## Facade Adapter Pattern
+
+Use this pattern when a feature needs swappable implementations behind a stable module API, such as configuration or storage.
+
+- **Facade module** — the stable module called by feature code, e.g. `PhxDiff.Config` or `PhxDiff.Diffs.AppRepo.Store`. It declares `@behaviour Namespace.Adapter`, exposes public functions with `@spec`, and delegates each call to the configured adapter.
+- **Adapter behaviour module** — the callback contract under the facade namespace, e.g. `PhxDiff.Config.Adapter` or `PhxDiff.Diffs.AppRepo.Store.Adapter`. It owns the `@callback` definitions and only includes return values that real adapters can return.
+- **Concrete adapter module** — an implementation of the behaviour, e.g. `PhxDiff.Config.DefaultAdapter` or `PhxDiff.Diffs.AppRepo.Store.FileSystem`. It declares `@behaviour Namespace.Adapter` and contains implementation-specific reads, file access, service calls, or default lookups.
+- **Configuration entry point** — the place the facade uses to find its adapter. For app configuration, read `Application.get_env/3` only in the facade's private `adapter/0`. For feature adapters selected by config, route through `PhxDiff.Config` or `PhxDiffWeb.Config` rather than reading application env directly.
+
+When recreating the pattern, feature code should call the facade, never the concrete adapter. Tests should swap the adapter at the configuration layer when mocking is needed.
+
 ## Code Organization
 
 - **`PhxDiff`** — core business logic (diff computation, app specs, file access)

--- a/lib/phx_diff/diffs/app_repo.ex
+++ b/lib/phx_diff/diffs/app_repo.ex
@@ -4,6 +4,7 @@ defmodule PhxDiff.Diffs.AppRepo do
   alias PhxDiff.AppSpecification
   alias PhxDiff.Diffs.AppRepo.AppGenerator
   alias PhxDiff.Diffs.AppRepo.AppSpecPath
+  alias PhxDiff.Diffs.AppRepo.Store
 
   @type version :: PhxDiff.Diffs.version()
 
@@ -38,22 +39,21 @@ defmodule PhxDiff.Diffs.AppRepo do
   @spec fetch_app_path(AppSpecification.t()) ::
           {:ok, String.t()} | {:error, :invalid_version}
   def fetch_app_path(%AppSpecification{} = app_specification) do
-    store().fetch_app_path(app_specification)
+    Store.fetch_app_path(app_specification)
   end
 
   @spec list_sample_apps_for_version(Version.t()) :: [AppSpecification.t()]
   def list_sample_apps_for_version(%Version{} = version) do
-    case store().list_app_specs_for_version(version) do
-      {:ok, app_specs} -> app_specs
-      {:error, :storage_unavailable} -> []
-    end
+    {:ok, app_specs} = Store.list_app_specs_for_version(version)
+
+    app_specs
   end
 
   @spec generate_sample_app(AppSpecification.t()) ::
           {:ok, String.t()} | {:error, :unknown_version}
   def generate_sample_app(%AppSpecification{} = app_spec) do
     with {:ok, app_dir} <- AppGenerator.generate(app_spec) do
-      store().store_generated_app(app_spec, app_dir)
+      Store.store_generated_app(app_spec, app_dir)
     end
   end
 
@@ -122,11 +122,8 @@ defmodule PhxDiff.Diffs.AppRepo do
   end
 
   defp app_specifications_for_pre_generated_apps do
-    case store().list_app_specs() do
-      {:ok, app_specs} -> app_specs
-      {:error, :storage_unavailable} -> []
-    end
-  end
+    {:ok, app_specs} = Store.list_app_specs()
 
-  defp store, do: PhxDiff.Config.app_repo_store()
+    app_specs
+  end
 end

--- a/lib/phx_diff/diffs/app_repo/store.ex
+++ b/lib/phx_diff/diffs/app_repo/store.ex
@@ -1,15 +1,35 @@
 defmodule PhxDiff.Diffs.AppRepo.Store do
   @moduledoc false
 
+  @behaviour PhxDiff.Diffs.AppRepo.Store.Adapter
+
   alias PhxDiff.AppSpecification
 
-  @type fetch_error :: :invalid_version | :storage_unavailable
-  @type store_error :: :storage_unavailable
+  @impl true
+  @spec list_app_specs() :: {:ok, [AppSpecification.t()]}
+  def list_app_specs do
+    adapter().list_app_specs()
+  end
 
-  @callback list_app_specs() :: {:ok, [AppSpecification.t()]} | {:error, :storage_unavailable}
-  @callback list_app_specs_for_version(Version.t()) ::
-              {:ok, [AppSpecification.t()]} | {:error, :storage_unavailable}
-  @callback fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, fetch_error}
-  @callback store_generated_app(AppSpecification.t(), String.t()) ::
-              {:ok, String.t()} | {:error, store_error}
+  @impl true
+  @spec list_app_specs_for_version(Version.t()) :: {:ok, [AppSpecification.t()]}
+  def list_app_specs_for_version(%Version{} = version) do
+    adapter().list_app_specs_for_version(version)
+  end
+
+  @impl true
+  @spec fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, :invalid_version}
+  def fetch_app_path(%AppSpecification{} = app_spec) do
+    adapter().fetch_app_path(app_spec)
+  end
+
+  @impl true
+  @spec store_generated_app(AppSpecification.t(), String.t()) :: {:ok, String.t()}
+  def store_generated_app(%AppSpecification{} = app_spec, source_path) do
+    adapter().store_generated_app(app_spec, source_path)
+  end
+
+  defp adapter do
+    PhxDiff.Config.app_repo_store()
+  end
 end

--- a/lib/phx_diff/diffs/app_repo/store/adapter.ex
+++ b/lib/phx_diff/diffs/app_repo/store/adapter.ex
@@ -1,0 +1,10 @@
+defmodule PhxDiff.Diffs.AppRepo.Store.Adapter do
+  @moduledoc false
+
+  alias PhxDiff.AppSpecification
+
+  @callback list_app_specs() :: {:ok, [AppSpecification.t()]}
+  @callback list_app_specs_for_version(Version.t()) :: {:ok, [AppSpecification.t()]}
+  @callback fetch_app_path(AppSpecification.t()) :: {:ok, String.t()} | {:error, :invalid_version}
+  @callback store_generated_app(AppSpecification.t(), String.t()) :: {:ok, String.t()}
+end

--- a/lib/phx_diff/diffs/app_repo/store/file_system.ex
+++ b/lib/phx_diff/diffs/app_repo/store/file_system.ex
@@ -1,7 +1,7 @@
 defmodule PhxDiff.Diffs.AppRepo.Store.FileSystem do
   @moduledoc false
 
-  @behaviour PhxDiff.Diffs.AppRepo.Store
+  @behaviour PhxDiff.Diffs.AppRepo.Store.Adapter
 
   alias PhxDiff.AppSpecification
   alias PhxDiff.Diffs.AppRepo.AppSpecPath


### PR DESCRIPTION
## Summary
- Move AppRepo store callbacks into `Store.Adapter` and make `Store` the facade used by feature code.
- Tighten store callback return types to match the filesystem adapter behavior.
- Document the facade adapter pattern and module roles in coding practices.

## Testing
- `mix test test/phx_diff/diffs/app_repo_test.exs`